### PR TITLE
Patch improvements

### DIFF
--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -357,12 +357,14 @@ module BranchIOCLI
           mode: :prepend
         )
 
-        # TODO: This is Swift 3. Support other versions, esp. 4.
-        init_session_text = <<-EOF
+        init_session_text = ConfigurationHelper.keys.count <= 1 ? "" : <<EOF
         #if DEBUG
             Branch.setUseTestBranchKey(true)
         #endif
 
+EOF
+
+        init_session_text += <<-EOF
         Branch.getInstance().initSession(launchOptions: launchOptions) {
             universalObject, linkProperties, error in
 
@@ -417,11 +419,14 @@ module BranchIOCLI
           mode: :prepend
         )
 
-        init_session_text = <<-EOF
+        init_session_text = ConfigurationHelper.keys.count <= 1 ? "" : <<EOF
 #ifdef DEBUG
     [Branch setUseTestBranchKey:YES];
 #endif // DEBUG
 
+EOF
+
+        init_session_text += <<-EOF
     [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
         andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
         // TODO: Route Branch links

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -379,13 +379,29 @@ EOF
           mode: :append
         )
 
-        unless app_delegate =~ /application:.*continueUserActivity:.*restorationHandler:/
+        if app_delegate =~ /application:.*continue userActivity:.*restorationHandler:/
+          # Add something to the top of the method
+          continue_user_activity_text = <<-EOF
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance.continue(userActivity) {
+            return true
+        }
+
+          EOF
+
+          apply_patch(
+            files: app_delegate_swift_path,
+            regexp: /application:.*continue userActivity:.*restorationHandler:.*?\{.*?\n/m,
+            text: continue_user_activity_text,
+            mode: :append
+          )
+        else
           # Add the application:continueUserActivity:restorationHandler method if it does not exist
           continue_user_activity_text = <<-EOF
 
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-      return Branch.getInstance().continue(userActivity)
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        return Branch.getInstance().continue(userActivity)
     }
           EOF
 
@@ -440,7 +456,22 @@ EOF
           mode: :append
         )
 
-        unless app_delegate =~ /application:.*continueUserActivity:.*restorationHandler:/
+        if app_delegate =~ /application:.*continueUserActivity:.*restorationHandler:/
+          continue_user_activity_text = <<-EOF
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] continueUserActivity:userActivity]) {
+        return YES;
+    }
+
+EOF
+
+          apply_patch(
+            files: app_delegate_objc_path,
+            regexp: /application:.*continueUserActivity:.*restorationHandler:.*?\{.*?\n/m,
+            text: continue_user_activity_text,
+            mode: :append
+          )
+        else
           # Add the application:continueUserActivity:restorationHandler method if it does not exist
           continue_user_activity_text = <<-EOF
 


### PR DESCRIPTION
- Fixed a bug in the Swift AppDelegate patch. It would add an openURL method that called `Branch.getInstance().continueUserActivity(userActivity)`. The Objective-C method works correctly.
- Only add conditional call to `setUseTestBranchKey` when multiple keys provided.
- Add to an existing `continueUserActivity` method (call to `Branch.getInstance().continueUserActivity(userActivity)` and return immediately if it returns true. Since the `branch_universal_link_domains` key is automatically set up, this should work fine.