### PR TITLE
Improve domain handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,30 @@ branch_io setup
 Integrates the Branch SDK into a native app project. This currently supports iOS only.
 It will infer the project location if there is exactly one .xcodeproj anywhere under
 the current directory, excluding any in a Pods or Carthage folder. Otherwise, specify
-the project location using the `--xcodeproj` option.
+the project location using the `--xcodeproj` option, or the CLI will prompt you for the
+location.
 
 If a Podfile or Cartfile is detected, the Branch SDK will be added to the relevant
 configuration file and the dependencies updated to include the Branch framework.
 This behavior may be suppressed using `--no_add_sdk`. If no Podfile or Cartfile
 is found, and Branch.framework is not already among the project's dependencies,
-you will be prompted for a number of choices.
+you will be prompted for a number of choices, including setting up CocoaPods or
+Carthage for the project or directly installing the Branch.framework.
 
 By default, all supplied Universal Link domains are validated. If validation passes,
 the setup continues. If validation fails, no further action is taken. Suppress
 validation using `--no_validate` or force changes when validation fails using
 `--force`.
 
-All relevant project settings are modified. The Branch keys are added to the Info.plist,
+By default, this command will look for the first app target in the project. Test
+targets are not supported. To set up an extension target, supply the `--target` option.
+
+All relevant target settings are modified. The Branch keys are added to the Info.plist,
 along with the `branch_universal_link_domains` key for custom domains (when `--domains`
-is used). All domains are added to the project's Associated Domains entitlements.
-An entitlements file is added if none is found. Optionally, if `--frameworks` is
-specified, this command can add a list of system frameworks to the project (e.g.,
-AdSupport, CoreSpotlight, SafariServices).
+is used). For app targets, all domains are added to the project's Associated Domains
+entitlement. An entitlements file is also added for app targets if none is found.
+Optionally, if `--frameworks` is specified, this command can add a list of system
+frameworks to the target's dependencies (e.g., AdSupport, CoreSpotlight, SafariServices).
 
 A language-specific patch is applied to the AppDelegate (Swift or Objective-C).
 This can be suppressed using `--no_patch_source`.
@@ -113,6 +118,10 @@ this command operates directly on the project. It finds the bundle and
 signing team identifiers in the project as well as the app's Associated Domains.
 It requests the apple-app-site-association file for each domain and validates
 the file against the project's settings.
+
+Only app targets are supported for this command. By default, it will validate the first.
+If your project has multiple app targets, specify the <%= color('--target', BOLD) %> option to validate other
+targets.
 
 #### Options
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -20,25 +20,30 @@ EOF
 Integrates the Branch SDK into a native app project. This currently supports iOS only.
 It will infer the project location if there is exactly one .xcodeproj anywhere under
 the current directory, excluding any in a Pods or Carthage folder. Otherwise, specify
-the project location using the <%= color('--xcodeproj', BOLD) %> option.
+the project location using the <%= color('--xcodeproj', BOLD) %> option, or the CLI will prompt you for the
+location.
 
 If a Podfile or Cartfile is detected, the Branch SDK will be added to the relevant
 configuration file and the dependencies updated to include the Branch framework.
 This behavior may be suppressed using <%= color('--no_add_sdk', BOLD) %>. If no Podfile or Cartfile
 is found, and Branch.framework is not already among the project's dependencies,
-you will be prompted for a number of choices.
+you will be prompted for a number of choices, including setting up CocoaPods or
+Carthage for the project or directly installing the Branch.framework.
 
 By default, all supplied Universal Link domains are validated. If validation passes,
 the setup continues. If validation fails, no further action is taken. Suppress
 validation using <%= color('--no_validate', BOLD) %> or force changes when validation fails using
 <%= color('--force', BOLD) %>.
 
-All relevant project settings are modified. The Branch keys are added to the Info.plist,
+By default, this command will look for the first app target in the project. Test
+targets are not supported. To set up an extension target, supply the <%= color('--target', BOLD) %> option.
+
+All relevant target settings are modified. The Branch keys are added to the Info.plist,
 along with the <%= color('branch_universal_link_domains', BOLD) %> key for custom domains (when <%= color('--domains', BOLD) %>
-is used). All domains are added to the project's Associated Domains entitlements.
-An entitlements file is added if none is found. Optionally, if <%= color('--frameworks', BOLD) %> is
-specified, this command can add a list of system frameworks to the project (e.g.,
-AdSupport, CoreSpotlight, SafariServices).
+is used). For app targets, all domains are added to the project's Associated Domains
+entitlement. An entitlements file is also added for app targets if none is found.
+Optionally, if <%= color('--frameworks', BOLD) %> is specified, this command can add a list of system
+frameworks to the target's dependencies (e.g., AdSupport, CoreSpotlight, SafariServices).
 
 A language-specific patch is applied to the AppDelegate (Swift or Objective-C).
 This can be suppressed using <%= color('--no_patch_source', BOLD) %>.
@@ -94,17 +99,22 @@ EOF
         c.syntax = "branch_io validate [OPTIONS]"
         c.summary = "Validates all Universal Link domains configured in a project"
         c.description = <<EOF
-This command validates all Universal Link domains configured in a project without making any modification.
-It validates both Branch and non-Branch domains. Unlike web-based Universal Link validators,
-this command operates directly on the project. It finds the bundle and
-signing team identifiers in the project as well as the app's Associated Domains.
-It requests the apple-app-site-association file for each domain and validates
-the file against the project's settings.
+This command validates all Universal Link domains configured in a project without making any
+modification. It validates both Branch and non-Branch domains. Unlike web-based Universal
+Link validators, this command operates directly on the project. It finds the bundle and
+signing team identifiers in the project as well as the app's Associated Domains. It requests
+the apple-app-site-association file for each domain and validates the file against the
+project's settings.
 
-All parameters are optional. If <%= color('--domains', BOLD) %> is specified, the list of Universal Link domains in the
-Associated Domains entitlement must exactly match this list, without regard to order. If no <%= color('--domains', BOLD) %>
-are provided, validation passes if at least one Universal Link domain is configured and passes validation,
-and no Universal Link domain is present that does not pass validation.
+Only app targets are supported for this command. By default, it will validate the first.
+If your project has multiple app targets, specify the <%= color('--target', BOLD) %> option to validate other
+targets.
+
+All parameters are optional. If <%= color('--domains', BOLD) %> is specified, the list of Universal Link domains in
+the Associated Domains entitlement must exactly match this list, without regard to order. If
+no <%= color('--domains', BOLD) %> are provided, validation passes if at least one Universal Link domain is
+configured and passes validation, and no Universal Link domain is present that does not pass
+validation.
 
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.
 EOF

--- a/lib/branch_io_cli/command.rb
+++ b/lib/branch_io_cli/command.rb
@@ -15,7 +15,7 @@ module BranchIOCLI
         update_podfile(options) || update_cartfile(options, xcodeproj)
 
         target_name = options.target # may be nil
-        is_app_target = !ConfigurationHelper.target.extension_target_type?
+        is_app_target = !Helper::ConfigurationHelper.target.extension_target_type?
 
         if is_app_target && !options.no_validate &&
            !helper.validate_team_and_bundle_ids_from_aasa_files(xcodeproj, target_name, @domains)

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -29,9 +29,10 @@ module BranchIOCLI
           validate_all_domains options, !@target.extension_target_type?
           validate_buildfile_path options, "Podfile"
           validate_buildfile_path options, "Cartfile"
-          validate_sdk_addition options
 
           print_setup_configuration
+
+          validate_sdk_addition options
         end
 
         def validate_validation_options(options)
@@ -53,6 +54,7 @@ EOF
 
         def print_setup_configuration
           say <<EOF
+
 <%= color('Configuration:', BOLD) %>
 
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
@@ -62,6 +64,7 @@ EOF
 <%= color('Domains:', BOLD) %> #{@all_domains}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || "(none)"}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || "(none)"}
+
 EOF
         end
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -6,6 +6,7 @@ require "zip"
 
 module BranchIOCLI
   module Helper
+    # rubocop: disable Metrics/ClassLength
     class ConfigurationHelper
       class << self
         APP_LINK_REGEXP = /\.app\.link$|\.test-app\.link$/
@@ -59,11 +60,11 @@ EOF
 
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
 <%= color('Target:', BOLD) %> #{@target.name}
-<%= color('Live key:', BOLD) %> #{@keys[:live] || "(none)"}
-<%= color('Test key:', BOLD) %> #{@keys[:test] || "(none)"}
+<%= color('Live key:', BOLD) %> #{@keys[:live] || '(none)'}
+<%= color('Test key:', BOLD) %> #{@keys[:test] || '(none)'}
 <%= color('Domains:', BOLD) %> #{@all_domains}
-<%= color('Podfile:', BOLD) %> #{@podfile_path || "(none)"}
-<%= color('Cartfile:', BOLD) %> #{@cartfile_path || "(none)"}
+<%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
+<%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
 
 EOF
         end
@@ -185,8 +186,8 @@ EOF
           return [] if domains.nil?
 
           domains.select { |d| d =~ APP_LINK_REGEXP }
-            .map { |d| d.sub(APP_LINK_REGEXP, '').sub(/-alternate$/, '') }
-            .uniq
+                 .map { |d| d.sub(APP_LINK_REGEXP, '').sub(/-alternate$/, '') }
+                 .uniq
         end
 
         def custom_domains_from_domains(domains)
@@ -477,4 +478,5 @@ EOF
       end
     end
   end
+  # rubocop enable: Metrics/ClassLength
 end

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -28,11 +28,27 @@ module BranchIOCLI
           validate_buildfile_path options, "Podfile"
           validate_buildfile_path options, "Cartfile"
           validate_sdk_addition options
+
+          print_configuration "setup"
         end
 
         def validate_validation_options(options)
           validate_xcodeproj_path options
           validate_target options, false
+
+          print_configuration "validate"
+        end
+
+        def print_configuration(command)
+          say "Configuration: "
+          say ""
+          say "- Xcode project: #{@xcodeproj_path}"
+          say "- Target: #{@target.name}"
+          say "- Live key: #{@keys[:live] || "(none)"}"
+          say "- Test key: #{@keys[:test] || "(none)"}"
+          say "- Domains: #{@all_domains}"
+          say "- Podfile: #{@podfile_path || "(none)"}"
+          say "- Cartfile: #{@cartfile_path || "(none)"}"
         end
 
         def validate_keys_from_setup_options(options)
@@ -63,7 +79,9 @@ module BranchIOCLI
           # .app.link or .test-app.link domains provided via options.domains.
 
           app_link_subdomains = app_link_subdomains_from_roots app_link_roots
-          custom_domains = custom_domains_from_domains domains
+
+          custom_domains = custom_domains_from_domains options.domains
+
           @all_domains = (app_link_subdomains + custom_domains).uniq
 
           while required && @all_domains.empty?
@@ -139,9 +157,9 @@ module BranchIOCLI
         def app_link_roots_from_domains(domains)
           return [] if domains.nil?
 
-          options.domains.select { |d| d =~ APP_LINK_REGEXP }
-                 .map { |d| d.sub!(APP_LINK_REGEXP, '').sub!(/-alternate$/, '') }
-                 .uniq
+          domains.select { |d| d =~ APP_LINK_REGEXP }
+            .map { |d| d.sub(APP_LINK_REGEXP, '').sub(/-alternate$/, '') }
+            .uniq
         end
 
         def custom_domains_from_domains(domains)

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -19,6 +19,8 @@ module BranchIOCLI
         attr_accessor :target
 
         def validate_setup_options(options)
+          print_identification "setup"
+
           say "--force is ignored when --no_validate is used." if options.no_validate && options.force
 
           validate_xcodeproj_path options
@@ -29,26 +31,48 @@ module BranchIOCLI
           validate_buildfile_path options, "Cartfile"
           validate_sdk_addition options
 
-          print_configuration "setup"
+          print_setup_configuration
         end
 
         def validate_validation_options(options)
+          print_identification "validate"
+
           validate_xcodeproj_path options
           validate_target options, false
 
-          print_configuration "validate"
+          print_validation_configuration
         end
 
-        def print_configuration(command)
-          say "Configuration: "
-          say ""
-          say "- Xcode project: #{@xcodeproj_path}"
-          say "- Target: #{@target.name}"
-          say "- Live key: #{@keys[:live] || "(none)"}"
-          say "- Test key: #{@keys[:test] || "(none)"}"
-          say "- Domains: #{@all_domains}"
-          say "- Podfile: #{@podfile_path || "(none)"}"
-          say "- Cartfile: #{@cartfile_path || "(none)"}"
+        def print_identification(command)
+          say <<EOF
+
+<%= color("branch_io #{command} v. #{VERSION}", BOLD) %>
+
+EOF
+        end
+
+        def print_setup_configuration
+          say <<EOF
+<%= color('Configuration:', BOLD) %>
+
+<%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
+<%= color('Target:', BOLD) %> #{@target.name}
+<%= color('Live key:', BOLD) %> #{@keys[:live] || "(none)"}
+<%= color('Test key:', BOLD) %> #{@keys[:test] || "(none)"}
+<%= color('Domains:', BOLD) %> #{@all_domains}
+<%= color('Podfile:', BOLD) %> #{@podfile_path || "(none)"}
+<%= color('Cartfile:', BOLD) %> #{@cartfile_path || "(none)"}
+EOF
+        end
+
+        def print_validation_configuration
+          say <<EOF
+<%= color('Configuration:', BOLD) %>
+
+<%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
+<%= color('Target:', BOLD) %> #{@target.name}
+<%= color('Domains:', BOLD) %> #{@all_domains}
+EOF
         end
 
         def validate_keys_from_setup_options(options)


### PR DESCRIPTION
app.link subdomains may now be passed via the --domains option, e.g. --domains myapp.app.link. Any of the four subdomains (incl. myapp-alternate.app.link,myapp.test-app.link,myapp-alternate.test-app.link) may be supplied. The CLI will provide all relevant domains (all four if using both keys; only app.link or test-app.link if only a live or test key is supplied).

Output has been improved considerably.

The help has been updated for recent changes.