### PR TITLE
URI schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ command, respectively, available in your path.
 |--test_key key_test_yyyy|Branch test key|
 |--app_link_subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
 |--domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
+|--uri_scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -76,6 +76,7 @@ EOF
         c.option "--test_key key_test_yyyy", String, "Branch test key"
         c.option "--app_link_subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
         c.option "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
+        c.option "--uri_scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"

--- a/lib/branch_io_cli/command.rb
+++ b/lib/branch_io_cli/command.rb
@@ -29,6 +29,8 @@ module BranchIOCLI
         # the following calls can all raise IOError
         helper.add_keys_to_info_plist xcodeproj, target_name, @keys
         helper.add_branch_universal_link_domains_to_info_plist xcodeproj, target_name, @domains if is_app_target
+        helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present
+
         new_path = helper.add_universal_links_to_project xcodeproj, target_name, @domains, false if is_app_target
         `git add #{new_path}` if options.commit && new_path
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -18,6 +18,7 @@ module BranchIOCLI
         attr_accessor :podfile_path
         attr_accessor :cartfile_path
         attr_accessor :target
+        attr_accessor :uri_scheme
 
         def validate_setup_options(options)
           print_identification "setup"
@@ -28,6 +29,7 @@ module BranchIOCLI
           validate_target options
           validate_keys_from_setup_options options
           validate_all_domains options, !@target.extension_target_type?
+          validate_uri_scheme options
           validate_buildfile_path options, "Podfile"
           validate_buildfile_path options, "Cartfile"
 
@@ -63,6 +65,7 @@ EOF
 <%= color('Live key:', BOLD) %> #{@keys[:live] || '(none)'}
 <%= color('Test key:', BOLD) %> #{@keys[:test] || '(none)'}
 <%= color('Domains:', BOLD) %> #{@all_domains}
+<%= color('URI scheme:', BOLD) %> #{@uri_scheme || '(none)'}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
 
@@ -117,6 +120,11 @@ EOF
 
             @all_domains = all_domains_from_domains domains
           end
+        end
+
+        def validate_uri_scheme(options)
+          # No validation at the moment. Just strips off any trailing ://
+          @uri_scheme = uri_scheme_without_suffix options.uri_scheme
         end
 
         # 1. Look for options.xcodeproj.
@@ -227,6 +235,11 @@ EOF
           app_link_subdomains = app_link_subdomains_from_roots app_link_roots
           custom_domains = custom_domains_from_domains domains
           custom_domains + app_link_subdomains
+        end
+
+        # Removes any trailing :// from the argument and returns a copy
+        def uri_scheme_without_suffix(scheme)
+          scheme.sub %r{://$}, ""
         end
 
         def validate_buildfile_path(options, filename)

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -239,6 +239,7 @@ EOF
 
         # Removes any trailing :// from the argument and returns a copy
         def uri_scheme_without_suffix(scheme)
+          return nil if scheme.nil?
           scheme.sub %r{://$}, ""
         end
 

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -537,11 +537,11 @@ EOF
 
       def patch_open_url_method_swift(app_delegate_swift_path)
         app_delegate_swift = File.open app_delegate_swift_path, &:read
-        if app_delegate_swift =~ /application:.*open\s+url.*options/
+        if app_delegate_swift =~ /application.*open\s+url.*options/
           # Has application:openURL:options:
           open_url_text = <<-EOF
         // TODO: Adjust your method as you see fit.
-        if Branch.getInstance.application(app, open: URL, options: options) {
+        if Branch.getInstance().application(app, open: url, options: options) {
             return true
         }
 
@@ -549,16 +549,16 @@ EOF
 
           apply_patch(
             files: app_delegate_swift_path,
-            regexp: /application:.*open\s+url.*options:.*?\{.*?\n/m,
+            regexp: /application.*open\s+url.*options:.*?\{.*?\n/m,
             text: open_url_text,
             mode: :append
           )
-        elsif app_delegate_swift =~ /application:.*open\s+url.*sourceApplication/
+        elsif app_delegate_swift =~ /application.*open\s+url.*sourceApplication/
           # Has application:openURL:sourceApplication:annotation:
           # TODO: This method is deprecated.
           open_url_text = <<-EOF
         // TODO: Adjust your method as you see fit.
-        if Branch.getInstance.application(application, open: URL, sourceApplication: sourceApplication, annotation: annotation) {
+        if Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation) {
             return true
         }
 
@@ -566,7 +566,7 @@ EOF
 
           apply_patch(
             files: app_delegate_swift_path,
-            regexp: /application:.*open\s+url.*sourceApplication:.*?\{.*?\n/m,
+            regexp: /application.*open\s+url.*sourceApplication:.*?\{.*?\n/m,
             text: open_url_text,
             mode: :append
           )
@@ -595,7 +595,7 @@ EOF
           # Has application:openURL:options:
           open_url_text = <<-EOF
     // TODO: Adjust your method as you see fit.
-    if ([[Branch getInstance] application:app openURL:URL options:options]) {
+    if ([[Branch getInstance] application:app openURL:url options:options]) {
         return YES;
     }
 
@@ -611,7 +611,7 @@ EOF
           # Has application:openURL:sourceApplication:annotation:
           open_url_text = <<-EOF
     // TODO: Adjust your method as you see fit.
-    if ([[Branch getInstance] application:application openURL:URL sourceApplication:sourceApplication annotation:annotation]) {
+    if ([[Branch getInstance] application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
         return YES;
     }
 

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -572,13 +572,13 @@ EOF
           )
         else
           # Has neither
-          open_url_text = <<-EOF
+          open_url_text = <<EOF
 
 
-          func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-              return Branch.getInstance().application(app, open: url, options: options)
-          }
-          EOF
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        return Branch.getInstance().application(app, open: url, options: options)
+    }
+EOF
 
           apply_patch(
             files: app_delegate_swift_path,


### PR DESCRIPTION
- Added a `--uri_scheme` option. Use either `--uri_scheme myurischeme` or `--uri_scheme myurischeme://`. The setup command will validate that it is present and add it if not.
- Added source code patches for Swift and Objective-C to add or patch the `application:openURL:options:` or `application:openURL:sourceApplication:annotation:` method. The former is preferred unless the latter is found.