### PR TITLE
Update options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ location.
 
 If a Podfile or Cartfile is detected, the Branch SDK will be added to the relevant
 configuration file and the dependencies updated to include the Branch framework.
-This behavior may be suppressed using `--no_add_sdk`. If no Podfile or Cartfile
+This behavior may be suppressed using `--no-add-sdk`. If no Podfile or Cartfile
 is found, and Branch.framework is not already among the project's dependencies,
 you will be prompted for a number of choices, including setting up CocoaPods or
 Carthage for the project or directly installing the Branch.framework.
 
 By default, all supplied Universal Link domains are validated. If validation passes,
 the setup continues. If validation fails, no further action is taken. Suppress
-validation using `--no_validate` or force changes when validation fails using
+validation using `--no-validate` or force changes when validation fails using
 `--force`.
 
 By default, this command will look for the first app target in the project. Test
@@ -67,7 +67,7 @@ Optionally, if `--frameworks` is specified, this command can add a list of syste
 frameworks to the target's dependencies (e.g., AdSupport, CoreSpotlight, SafariServices).
 
 A language-specific patch is applied to the AppDelegate (Swift or Objective-C).
-This can be suppressed using `--no_patch_source`.
+This can be suppressed using `--no-patch-source`.
 
 #### Prerequisites
 
@@ -86,26 +86,26 @@ command, respectively, available in your path.
 
 |Option|Description|
 |------|-----------|
-|--live_key key_live_xxxx|Branch live key|
-|--test_key key_test_yyyy|Branch test key|
-|--app_link_subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
+|--live-key key_live_xxxx|Branch live key|
+|--test-key key_test_yyyy|Branch test key|
+|--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
 |--domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
-|--uri_scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
+|--uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|
 |--frameworks AdSupport,CoreSpotlight,SafariServices|Comma-separated list of system frameworks to add to the project|
-|--no_pod_repo_update|Skip update of the local podspec repo before installing|
-|--no_validate|Skip validation of Universal Link configuration|
-|--force|Update project even if Universal Link validation fails|
-|--no_add_sdk|Don't add the Branch framework to the project|
-|--no_patch_source|Don't add Branch SDK calls to the AppDelegate|
-|--commit|Commit the results to Git|
+|--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|
+|--[no-]validate|Validate Universal Link configuration (default: yes)|
+|--[no-]force|Update project even if Universal Link validation fails (default: no)|
+|--[no-]add-sdk|Add the Branch framework to the project (default: yes)|
+|--[no-]patch-source|Add Branch SDK calls to the AppDelegate (default: yes)|
+|--[no-]commit|Commit the results to Git (default: no)|
 
 All parameters are optional. A live key or test key, or both is required, as well as at least one domain.
-Specify --live_key, --test_key or both and --app_link_subdomain, --domains or both. If these are not
-specified, this command will prompt you for this information.
+Specify --live-key, --test-key or both and --app-link-subdomain, --domains or both. If these are not
+specified, this command will prompt you for the information.
 
 ### Validate command
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ command, respectively, available in your path.
 
 |Option|Description|
 |------|-----------|
-|--live-key key_live_xxxx|Branch live key|
-|--test-key key_test_yyyy|Branch test key|
+|-L, --live-key key_live_xxxx|Branch live key|
+|-T, --test-key key_test_yyyy|Branch test key|
 |--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
-|--domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
-|--uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
+|-D --domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
+|-U --uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
@@ -106,6 +106,32 @@ command, respectively, available in your path.
 All parameters are optional. A live key or test key, or both is required, as well as at least one domain.
 Specify --live-key, --test-key or both and --app-link-subdomain, --domains or both. If these are not
 specified, this command will prompt you for the information.
+
+#### Examples
+
+##### Test without validation (can use dummy keys and domains)
+
+```bash
+branch_io setup -L key_live_xxxx -D myapp.app.link --no-validate
+```
+
+##### Use both live and test keys
+
+```bash
+branch_io setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link
+```
+
+##### Use custom or non-Branch domains
+
+```bash
+branch_io setup -D myapp.app.link,example.com,www.example.com
+```
+
+##### Avoid pod repo update
+
+```bash
+branch_io setup --no-pod-repo-update
+```
 
 ### Validate command
 
@@ -128,7 +154,7 @@ targets.
 
 |Option|Description|
 |------|-----------|
-|--domains example.com,www.example.com|Comma-separated list of domains. May include app.link subdomains.|
+|-D, --domains example.com,www.example.com|Comma-separated list of domains. May include app.link subdomains.|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -72,11 +72,11 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 EOF
 
         # Required Branch params
-        c.option "--live-key key_live_xxxx", String, "Branch live key"
-        c.option "--test-key key_test_yyyy", String, "Branch test key"
+        c.option "-L", "--live-key key_live_xxxx", String, "Branch live key"
+        c.option "-T", "--test-key key_test_yyyy", String, "Branch test key"
         c.option "--app-link-subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
-        c.option "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
-        c.option "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
+        c.option "-D", "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
+        c.option "-U", "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"
@@ -90,6 +90,11 @@ EOF
         c.option "--[no-]add-sdk", "Add the Branch framework to the project (default: yes)"
         c.option "--[no-]patch-source", "Add Branch SDK calls to the AppDelegate (default: yes)"
         c.option "--[no-]commit", "Commit the results to Git (default: no)"
+
+        c.example "Test without validation (can use dummy keys and domains)", "branch_io setup -L key_live_xxxx -D myapp.app.link --no-validate"
+        c.example "Use both live and test keys", "branch_io setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link"
+        c.example "Use custom or non-Branch domains", "branch_io setup -D myapp.app.link,example.com,www.example.com"
+        c.example "Avoid pod repo update", "branch_io setup --no-pod-repo-update"
 
         c.action do |args, options|
           options.default(
@@ -129,9 +134,9 @@ validation.
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.
 EOF
 
+        c.option "-D", "--domains example.com,www.example.com", Array, "Comma-separated list of domains to validate (Branch domains or non-Branch domains)"
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"
-        c.option "--domains example.com,www.example.com", Array, "Comma-separated list of domains to validate (Branch domains or non-Branch domains)"
 
         c.action do |args, options|
           valid = Command.validate options

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -25,14 +25,14 @@ location.
 
 If a Podfile or Cartfile is detected, the Branch SDK will be added to the relevant
 configuration file and the dependencies updated to include the Branch framework.
-This behavior may be suppressed using <%= color('--no_add_sdk', BOLD) %>. If no Podfile or Cartfile
+This behavior may be suppressed using <%= color('--no-add-sdk', BOLD) %>. If no Podfile or Cartfile
 is found, and Branch.framework is not already among the project's dependencies,
 you will be prompted for a number of choices, including setting up CocoaPods or
 Carthage for the project or directly installing the Branch.framework.
 
 By default, all supplied Universal Link domains are validated. If validation passes,
 the setup continues. If validation fails, no further action is taken. Suppress
-validation using <%= color('--no_validate', BOLD) %> or force changes when validation fails using
+validation using <%= color('--no-validate', BOLD) %> or force changes when validation fails using
 <%= color('--force', BOLD) %>.
 
 By default, this command will look for the first app target in the project. Test
@@ -46,7 +46,7 @@ Optionally, if <%= color('--frameworks', BOLD) %> is specified, this command can
 frameworks to the target's dependencies (e.g., AdSupport, CoreSpotlight, SafariServices).
 
 A language-specific patch is applied to the AppDelegate (Swift or Objective-C).
-This can be suppressed using <%= color('--no_patch_source', BOLD) %>.
+This can be suppressed using <%= color('--no-patch-source', BOLD) %>.
 
 <%= color('Prerequisites', BOLD) %>
 
@@ -64,7 +64,7 @@ To add the SDK with CocoaPods or Carthage, you must have the <%= color('pod', BO
 command, respectively, available in your path.
 
 All parameters are optional. A live key or test key, or both is required, as well
-as at least one domain. Specify <%= color('--live_key', BOLD) %>, <%= color('--test_key', BOLD) %> or both and <%= color('--app_link_subdomain', BOLD) %>,
+as at least one domain. Specify <%= color('--live-key', BOLD) %>, <%= color('--test-key', BOLD) %> or both and <%= color('--app-link-subdomain', BOLD) %>,
 <%= color('--domains', BOLD) %> or both. If these are not specified, this command will prompt you
 for this information.
 
@@ -72,11 +72,11 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 EOF
 
         # Required Branch params
-        c.option "--live_key key_live_xxxx", String, "Branch live key"
-        c.option "--test_key key_test_yyyy", String, "Branch test key"
-        c.option "--app_link_subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
+        c.option "--live-key key_live_xxxx", String, "Branch live key"
+        c.option "--test-key key_test_yyyy", String, "Branch test key"
+        c.option "--app-link-subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
         c.option "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
-        c.option "--uri_scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
+        c.option "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"
@@ -84,14 +84,23 @@ EOF
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--frameworks AdSupport,CoreSpotlight,SafariServices", Array, "Comma-separated list of system frameworks to add to the project"
 
-        c.option "--no_pod_repo_update", TrueClass, "Skip update of the local podspec repo before installing"
-        c.option "--no_validate", TrueClass, "Skip validation of Universal Link configuration"
-        c.option "--force", TrueClass, "Update project even if Universal Link validation fails"
-        c.option "--no_add_sdk", TrueClass, "Don't add the Branch framework to the project"
-        c.option "--no_patch_source", TrueClass, "Don't add Branch SDK calls to the AppDelegate"
-        c.option "--commit", TrueClass, "Commit the results to Git"
+        c.option "--[no-]pod-repo-update", "Update the local podspec repo before installing (default: yes)"
+        c.option "--[no-]validate", "Validate Universal Link configuration (default: yes)"
+        c.option "--[no-]force", "Update project even if Universal Link validation fails (default: no)"
+        c.option "--[no-]add-sdk", "Add the Branch framework to the project (default: yes)"
+        c.option "--[no-]patch-source", "Add Branch SDK calls to the AppDelegate (default: yes)"
+        c.option "--[no-]commit", "Commit the results to Git (default: no)"
 
         c.action do |args, options|
+          options.default(
+            # Defaults for boolean options
+            pod_repo_update: true,
+            validate: true,
+            force: false,
+            add_sdk: true,
+            patch_source: true,
+            commit: false
+          )
           Command.setup options
         end
       end

--- a/lib/branch_io_cli/command.rb
+++ b/lib/branch_io_cli/command.rb
@@ -17,12 +17,12 @@ module BranchIOCLI
         target_name = options.target # may be nil
         is_app_target = !Helper::ConfigurationHelper.target.extension_target_type?
 
-        if is_app_target && !options.no_validate &&
+        if is_app_target && options.validate &&
            !helper.validate_team_and_bundle_ids_from_aasa_files(xcodeproj, target_name, @domains)
           say "Universal Link configuration failed validation."
           helper.errors.each { |error| say " #{error}" }
           return unless options.force
-        elsif is_app_target && !options.no_validate
+        elsif is_app_target && options.validate
           say "Universal Link configuration passed validation. ✅"
         end
 
@@ -38,7 +38,7 @@ module BranchIOCLI
 
         xcodeproj.save
 
-        patch_source xcodeproj unless options.no_patch_source
+        patch_source xcodeproj if options.patch_source
 
         return unless options.commit
 
@@ -103,7 +103,7 @@ module BranchIOCLI
         # 2. pod install
         # command = "PATH='#{ENV['PATH']}' pod install"
         command = 'pod install'
-        command += ' --repo-update' unless options.no_pod_repo_update
+        command += ' --repo-update' if options.pod_repo_update
 
         Dir.chdir(File.dirname(podfile_path)) do
           system command

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -11,19 +11,32 @@ module BranchIOCLI
       class << self
         APP_LINK_REGEXP = /\.app\.link$|\.test-app\.link$/
 
-        attr_accessor :xcodeproj_path
-        attr_accessor :xcodeproj
-        attr_accessor :keys
-        attr_accessor :all_domains
-        attr_accessor :podfile_path
-        attr_accessor :cartfile_path
-        attr_accessor :target
-        attr_accessor :uri_scheme
+        attr_reader :xcodeproj_path
+        attr_reader :xcodeproj
+        attr_reader :keys
+        attr_reader :all_domains
+        attr_reader :podfile_path
+        attr_reader :cartfile_path
+        attr_reader :target
+        attr_reader :uri_scheme
+        attr_reader :pod_repo_update
+        attr_reader :validate
+        attr_reader :add_sdk
+        attr_reader :force
+        attr_reader :patch_source
+        attr_reader :commit
 
         def validate_setup_options(options)
           print_identification "setup"
 
-          say "--force is ignored when --no_validate is used." if options.no_validate && options.force
+          @pod_repo_update = options.pod_repo_update
+          @validate = options.validate
+          @patch_source = options.patch_source
+          @add_sdk = options.add_sdk
+          @force = options.force
+          @commit = options.commit
+
+          say "--force is ignored when --no-validate is used." if !options.validate && options.force
 
           validate_xcodeproj_path options
           validate_target options
@@ -57,7 +70,6 @@ EOF
 
         def print_setup_configuration
           say <<EOF
-
 <%= color('Configuration:', BOLD) %>
 
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
@@ -68,6 +80,12 @@ EOF
 <%= color('URI scheme:', BOLD) %> #{@uri_scheme || '(none)'}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
+<%= color('Pod repo update:', BOLD) %> #{@pod_repo_update.inspect}
+<%= color('Validate:', BOLD) %> #{@validate.inspect}
+<%= color('Force:', BOLD) %> #{@force.inspect}
+<%= color('Add SDK:', BOLD) %> #{@add_sdk.inspect}
+<%= color('Patch source:', BOLD) %> #{@patch_source.inspect}
+<%= color('Commit:', BOLD) %> #{@commit.inspect}
 
 EOF
         end
@@ -244,8 +262,8 @@ EOF
         end
 
         def validate_buildfile_path(options, filename)
-          # Disable Podfile/Cartfile update if --no_add_sdk is present
-          return if options.no_add_sdk
+          # Disable Podfile/Cartfile update if --no-add-sdk is present
+          return unless options.add_sdk
 
           buildfile_path = filename == "Podfile" ? options.podfile : options.cartfile
 
@@ -287,7 +305,7 @@ EOF
         end
 
         def validate_sdk_addition(options)
-          return if options.no_add_sdk || @podfile_path || @cartfile_path
+          return if !options.add_sdk || @podfile_path || @cartfile_path
 
           # If no CocoaPods or Carthage, check to see if the framework is linked.
           target = BranchHelper.target_from_project @xcodeproj, options.target
@@ -318,7 +336,7 @@ EOF
           target = BranchHelper.target_from_project @xcodeproj, options.target
 
           install_command = "pod install"
-          install_command += " --repo-update" unless options.no_pod_repo_update
+          install_command += " --repo-update" if options.pod_repo_update
           Dir.chdir(File.dirname(@podfile_path)) do
             system "pod init"
             BranchHelper.apply_patch(


### PR DESCRIPTION
Show options using hyphens instead of underscores in the README and help. Commander supports both styles, e.g. `branch_io --live-key key_live_xxxx` and `branch_io --live_key key_live_xxxx`. All previously listed options still work, but the former style looks nicer and is more standard.

Added single-letter options for Branch params in setup.

Added examples to help and docs for setup.