### PR TITLE
Report command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Gemfile.lock
 coverage
 test-results
 build
+report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 /rdoc/
 coverage
 test-results
+build

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Currently command-line completion for bash is much more extensive than for zsh.
 ### Setup command
 
 ```bash
-branch_io setup
+branch_io setup [OPTIONS]
 ```
 
 Integrates the Branch SDK into a native app project. This currently supports iOS only.
@@ -165,7 +165,7 @@ branch_io setup --no-pod-repo-update
 ### Validate command
 
 ```bash
-branch_io validate
+branch_io validate [OPTIONS]
 ```
 
 This command validates all Universal Link domains configured in a project without making any modification.
@@ -198,6 +198,35 @@ and no Universal Link domain is present that does not pass validation.
 #### Return value
 
 If validation passes, this command returns 0. If validation fails, it returns 1.
+
+### Report command
+
+```bash
+branch_io report [OPTIONS]
+```
+
+_Work in progress_
+
+This command optionally cleans and then builds a workspace or project, generating a verbose
+report with additional diagnostic information suitable for opening a support ticket.
+
+#### Options
+
+|Option|Description|
+|------|-----------|
+|-h, --help|Prints a list of commands or help for each command|
+|-v, --version|Prints the current version of the CLI|
+|-t, --trace|Prints a stack trace when exceptions are raised|
+|--workspace MyProject.xcworkspace|Path to an Xcode workspace|
+|--xcodeproj MyProject.xcodeproj|Path to an Xcode project|
+|--target MyAppTarget|Name of a target to modify in the Xcode project|
+|--scheme MyAppScheme|Name of a scheme to build|
+|--configuration Debug/Release/CustomConfig|Name of a build configuration|
+|--[no-]clean|Clean before building (default: yes)|
+|--[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|
+|--podfile /path/to/Podfile|Path to the Podfile for the project|
+|--cartfile /path/to/Cartfile|Path to the Cartfile for the project|
+|--out ./report.txt|Path to use for the generated report (default: ./report.txt)|
 
 ## Examples
 

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
-    report_opts="$global_opts --xcodeproj --workspace --no-clean --scheme --target --configuration --out"
+    report_opts="$global_opts --xcodeproj --workspace --header-only --no-clean --scheme --target --configuration --out"
 
     if [[ ${cur} == -* ]] ; then
       case "${cmd}" in

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -8,7 +8,7 @@ _branch_io_complete()
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     cmd="${COMP_WORDS[1]}"
 
-    commands="setup validate"
+    commands="report setup validate"
     global_opts="-h --help -t --trace -v --version"
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
@@ -18,8 +18,13 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
+    report_opts="$global_opts --xcodeproj"
+
     if [[ ${cur} == -* ]] ; then
       case "${cmd}" in
+        report)
+          opts=$report_opts
+          ;;
         setup)
           opts=$setup_opts
           ;;

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
-    report_opts="$global_opts --xcodeproj"
+    report_opts="$global_opts --xcodeproj --workspace --no-clean --scheme"
 
     if [[ ${cur} == -* ]] ; then
       case "${cmd}" in

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
-    report_opts="$global_opts --xcodeproj --workspace --no-clean --scheme"
+    report_opts="$global_opts --xcodeproj --workspace --no-clean --scheme --target --configuration --out"
 
     if [[ ${cur} == -* ]] ; then
       case "${cmd}" in

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -145,6 +145,21 @@ EOF
         end
       end
 
+      command :report do |c|
+        c.syntax = "branch_io report [OPTIONS]"
+        c.summary = "Generate and optionally submit a build diagnostic report."
+        c.description = <<EOF
+More to come.
+EOF
+
+        c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project"
+        c.option "--workspace MyProject.xcworkspace", String, "Path to an Xcode workspace"
+
+        c.action do |args, options|
+          Commands::ReportCommand.new(options).run!
+        end
+      end
+
       run!
     end
   end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -158,6 +158,7 @@ EOF
         c.option "--target MyProjectTarget", String, "A target to build"
         c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Release)"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
+        c.option "--out branch-report.txt", String, "Report output path (default: ./branch-report.txt)"
 
         c.action do |args, options|
           options.default clean: true

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -154,8 +154,11 @@ EOF
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project"
         c.option "--workspace MyProject.xcworkspace", String, "Path to an Xcode workspace"
+        c.option "--scheme MyProjectScheme", String, "A scheme from the project or workspace to build"
+        c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
 
         c.action do |args, options|
+          options.default clean: true
           Commands::ReportCommand.new(options).run!
         end
       end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -157,11 +157,14 @@ EOF
         c.option "--scheme MyProjectScheme", String, "A scheme from the project or workspace to build"
         c.option "--target MyProjectTarget", String, "A target to build"
         c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Release)"
+        c.option "--podfile /path/to/Podfile", String, "Path to the Podfile for the project"
+        c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
+        c.option "--[no-]header-only", "Write a report header to standard output and exit"
         c.option "--out branch-report.txt", String, "Report output path (default: ./branch-report.txt)"
 
         c.action do |args, options|
-          options.default clean: true
+          options.default clean: true, header_only: false
           Commands::ReportCommand.new(options).run!
         end
       end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -149,7 +149,10 @@ EOF
         c.syntax = "branch_io report [OPTIONS]"
         c.summary = "Generate and optionally submit a build diagnostic report."
         c.description = <<EOF
-More to come.
+<%= color('Work in progress', BOLD) %>
+
+This command optionally cleans and then builds a workspace or project, generating a verbose
+report with additional diagnostic information suitable for opening a support ticket.
 EOF
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project"

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -155,6 +155,8 @@ EOF
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project"
         c.option "--workspace MyProject.xcworkspace", String, "Path to an Xcode workspace"
         c.option "--scheme MyProjectScheme", String, "A scheme from the project or workspace to build"
+        c.option "--target MyProjectTarget", String, "A target to build"
+        c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Release)"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
 
         c.action do |args, options|

--- a/lib/branch_io_cli/commands.rb
+++ b/lib/branch_io_cli/commands.rb
@@ -1,3 +1,4 @@
 require "branch_io_cli/commands/command"
+require "branch_io_cli/commands/report_command"
 require "branch_io_cli/commands/setup_command"
 require "branch_io_cli/commands/validate_command"

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -30,12 +30,12 @@ module BranchIOCLI
       end
 
       def base_xcodebuild_cmd
-        cmd = "xcodebuild "
-        cmd = "#{cmd} -scheme #{config_helper.scheme} " if config_helper.scheme
-        cmd = "#{cmd} -workspace #{config_helper.workspace_path} " if config_helper.workspace_path
-        cmd = "#{cmd} -project #{config_helper.xcodeproj_path} " if config_helper.xcodeproj_path
-        cmd = "#{cmd} -target #{config_helper.target} " if config_helper.target
-        cmd = "#{cmd} -configuration #{config_helper.configuration} " if config_helper.configuration
+        cmd = "xcodebuild"
+        cmd = "#{cmd} -scheme #{config_helper.scheme}" if config_helper.scheme
+        cmd = "#{cmd} -workspace #{config_helper.workspace_path}" if config_helper.workspace_path
+        cmd = "#{cmd} -project #{config_helper.xcodeproj_path}" if config_helper.xcodeproj_path
+        cmd = "#{cmd} -target #{config_helper.target}" if config_helper.target
+        cmd = "#{cmd} -configuration #{config_helper.configuration}" if config_helper.configuration
         cmd
       end
 

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -8,6 +8,18 @@ module BranchIOCLI
       end
 
       def run!
+        system "#{base_xcodebuild_cmd} clean" if config_helper.clean
+        system "#{base_xcodebuild_cmd}"
+      end
+
+      def base_xcodebuild_cmd
+        cmd = "xcodebuild "
+        cmd = "#{cmd} -scheme #{config_helper.scheme} " if config_helper.scheme
+        cmd = "#{cmd} -workspace #{config_helper.workspace_path} " if config_helper.workspace_path
+        cmd = "#{cmd} -project #{config_helper.xcodeproj_path} " if config_helper.xcodeproj_path
+        cmd = "#{cmd} -target #{config_helper.target} " if config_helper.target
+        cmd = "#{cmd} -configuration #{config_helper.configuration} " if config_helper.configuration
+        cmd
       end
     end
   end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -8,8 +8,14 @@ module BranchIOCLI
       end
 
       def run!
-        system "#{base_xcodebuild_cmd} clean" if config_helper.clean
-        system "#{base_xcodebuild_cmd}"
+        File.open config_helper.report_path, "w" do |report|
+          say "Cleaning"
+          report.write `#{base_xcodebuild_cmd} clean` if config_helper.clean
+          say "Building"
+          report.write `#{base_xcodebuild_cmd}`
+          say "Done ✅"
+        end
+        say "Report generated in #{config_helper.report_path}"
       end
 
       def base_xcodebuild_cmd

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -9,10 +9,14 @@ module BranchIOCLI
 
       def run!
         File.open config_helper.report_path, "w" do |report|
+          report.write report_header
+
           say "Cleaning"
           report.write `#{base_xcodebuild_cmd} clean` if config_helper.clean
+
           say "Building"
           report.write `#{base_xcodebuild_cmd}`
+
           say "Done ✅"
         end
         say "Report generated in #{config_helper.report_path}"
@@ -26,6 +30,12 @@ module BranchIOCLI
         cmd = "#{cmd} -target #{config_helper.target} " if config_helper.target
         cmd = "#{cmd} -configuration #{config_helper.configuration} " if config_helper.configuration
         cmd
+      end
+
+      def report_header
+        <<EOF
+#{`xcodebuild -version`}
+EOF
       end
     end
   end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,0 +1,14 @@
+module BranchIOCLI
+  module Commands
+    class ReportCommand < Command
+
+      def initialize(options)
+        super
+        config_helper.validate_report_options options
+      end
+
+      def run!
+      end
+    end
+  end
+end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -9,13 +9,18 @@ module BranchIOCLI
 
       def run!
         File.open config_helper.report_path, "w" do |report|
-          report.write report_header
+          report.write "Branch.io Xcode build report v #{VERSION}\n\n"
+          report.write "#{report_header}\n"
 
           say "Cleaning"
-          report.write `#{base_xcodebuild_cmd} clean` if config_helper.clean
+          clean_cmd = "#{base_xcodebuild_cmd} clean"
+          report.write "$ #{clean_cmd}\n\n"
+          report.write `#{clean_cmd}` if config_helper.clean
 
           say "Building"
-          report.write `#{base_xcodebuild_cmd}`
+          build_cmd = "#{base_xcodebuild_cmd} -verbose"
+          report.write "$ #{build_cmd}\n\n"
+          report.write `#{build_cmd}`
 
           say "Done ✅"
         end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,7 +1,6 @@
 module BranchIOCLI
   module Commands
     class ReportCommand < Command
-
       def initialize(options)
         super
         config_helper.validate_report_options options

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -10,12 +10,15 @@ module BranchIOCLI
       def run!
         File.open config_helper.report_path, "w" do |report|
           report.write "Branch.io Xcode build report v #{VERSION}\n\n"
+          # TODO: Write out command-line options or configuration from helper
           report.write "#{report_header}\n"
 
-          say "Cleaning"
-          clean_cmd = "#{base_xcodebuild_cmd} clean"
-          report.write "$ #{clean_cmd}\n\n"
-          report.write `#{clean_cmd}` if config_helper.clean
+          if config_helper.clean
+            say "Cleaning"
+            clean_cmd = "#{base_xcodebuild_cmd} clean"
+            report.write "$ #{clean_cmd}\n\n"
+            report.write `#{clean_cmd}`
+          end
 
           say "Building"
           build_cmd = "#{base_xcodebuild_cmd} -verbose"

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -37,6 +37,7 @@ module BranchIOCLI
         attr_reader :clean
         attr_reader :scheme
         attr_reader :configuration
+        attr_reader :report_path
 
         def validate_setup_options(options)
           print_identification "setup"
@@ -91,6 +92,7 @@ module BranchIOCLI
           @scheme = options.scheme
           @target = options.target
           @configuration = options.configuration
+          @report_path = options.out || "./report.txt"
 
           validate_xcodeproj_and_workspace options
 
@@ -148,6 +150,7 @@ EOF
 <%= color('Target:', BOLD) %> #{@target || '(none)'}
 <%= color('Configuration:', BOLD) %> #{configuration || '(none)'}
 <%= color('Clean:', BOLD) %> #{@clean.inspect}
+<%= color('Report path:', BOLD) %> #{@report_path}
 EOF
         end
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -35,6 +35,8 @@ module BranchIOCLI
         attr_reader :commit
         attr_reader :sdk_integration_mode
         attr_reader :clean
+        attr_reader :scheme
+        attr_reader :configuration
 
         def validate_setup_options(options)
           print_identification "setup"
@@ -86,6 +88,9 @@ module BranchIOCLI
           print_identification "report"
 
           @clean = options.clean
+          @scheme = options.scheme
+          @target = options.target
+          @configuration = options.configuration
 
           validate_xcodeproj_and_workspace options
 
@@ -137,8 +142,11 @@ EOF
           say <<EOF
 <%= color('Configuration:', BOLD) %>
 
-<%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
-<%= color('Xcode workspace:', BOLD) %> #{@workspace_path}
+<%= color('Xcode workspace:', BOLD) %> #{@workspace_path || '(none)'}
+<%= color('Xcode project:', BOLD) %> #{@xcodeproj_path || '(none)'}
+<%= color('Scheme:', BOLD) %> #{@scheme || '(none)'}
+<%= color('Target:', BOLD) %> #{@target || '(none)'}
+<%= color('Configuration:', BOLD) %> #{configuration || '(none)'}
 <%= color('Clean:', BOLD) %> #{@clean.inspect}
 EOF
         end

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -19,6 +19,8 @@ module BranchIOCLI
       class << self
         attr_reader :xcodeproj_path
         attr_reader :xcodeproj
+        attr_reader :workspace_path
+        attr_reader :workspace
         attr_reader :keys
         attr_reader :all_domains
         attr_reader :podfile_path
@@ -79,6 +81,15 @@ module BranchIOCLI
           print_validation_configuration
         end
 
+        def validate_report_options(options)
+          print_identification "report"
+
+          @xcodeproj_path = options.xcodeproj
+          @workspace_path = options.workspace
+
+          print_report_configuration
+        end
+
         def print_identification(command)
           say <<EOF
 
@@ -117,6 +128,15 @@ EOF
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
 <%= color('Target:', BOLD) %> #{@target.name}
 <%= color('Domains:', BOLD) %> #{@all_domains || '(none)'}
+EOF
+        end
+
+        def print_report_configuration
+          say <<EOF
+<%= color('Configuration:', BOLD) %>
+
+<%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
+<%= color('Xcode workspace:', BOLD) %> #{@workspace_path}
 EOF
         end
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -68,10 +68,10 @@ module BranchIOCLI
 
           # If --cartfile is present, don't look for a Podfile. Just validate that
           # Cartfile.
-          validate_buildfile_path options, "Podfile" if options.cartfile.nil? && options.add_sdk
+          validate_buildfile_path options.podfile, "Podfile" if options.cartfile.nil? && options.add_sdk
 
           # If --podfile is present or a Podfile was found, don't look for a Cartfile.
-          validate_buildfile_path options, "Cartfile" if @podfile_path.nil? && options.add_sdk
+          validate_buildfile_path options.cartfile, "Cartfile" if @sdk_integration_mode.nil? && options.add_sdk
 
           validate_sdk_addition options
 
@@ -104,10 +104,10 @@ module BranchIOCLI
 
           # If --cartfile is present, don't look for a Podfile. Just validate that
           # Cartfile.
-          validate_buildfile_path(options, "Podfile") if options.cartfile.nil?
+          validate_buildfile_path(options.podfile, "Podfile") if options.cartfile.nil?
 
           # If --podfile is present or a Podfile was found, don't look for a Cartfile.
-          validate_buildfile_path(options, "Cartfile") if @sdk_integration_mode.nil?
+          validate_buildfile_path(options.cartfile, "Cartfile") if @sdk_integration_mode.nil?
 
           print_report_configuration
         end
@@ -397,11 +397,9 @@ EOF
           scheme.sub %r{://$}, ""
         end
 
-        def validate_buildfile_path(options, filename)
+        def validate_buildfile_path(buildfile_path, filename)
           # Disable Podfile/Cartfile update if --no-add-sdk is present
           return unless @sdk_integration_mode.nil?
-
-          buildfile_path = filename == "Podfile" ? options.podfile : options.cartfile
 
           # Was --podfile/--cartfile used?
           if buildfile_path
@@ -428,9 +426,8 @@ EOF
             end
           end
 
-          # No: Check for Podfile/Cartfile next to @xcodeproj_path
-          # TODO: Or @workspace_path
-          buildfile_path = File.expand_path "../#{filename}", @xcodeproj_path
+          # No: Check for Podfile/Cartfile next to workspace or project
+          buildfile_path = File.expand_path "../#{filename}", (@workspace_path || @xcodeproj_path)
           return unless File.exist? buildfile_path
 
           # Exists: Use it (valid if found)

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -331,7 +331,7 @@ EOF
             exit 1
           else
             say "No scheme defined in project."
-            exit -1
+            exit(-1)
           end
         end
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -6,6 +6,7 @@ module BranchIOCLI
     # Processes CLI options.
     # Validates options.
     # Prompts for input in a number of cases.
+    # rubocop: disable Metrics/ClassLength
     class ConfigurationHelper
       APP_LINK_REGEXP = /\.app\.link$|\.test-app\.link$/
       SDK_OPTIONS =
@@ -253,7 +254,7 @@ EOF
           end
 
           # Try to find first a workspace, then a project
-          all_workspace_paths = Dir[File.expand_path(File.join".", "**/*.xcworkspace")]
+          all_workspace_paths = Dir[File.expand_path(File.join(".", "**/*.xcworkspace"))]
           if all_workspace_paths.count == 1
             path = all_workspace_paths.first
           elsif all_workspace_paths.count == 0
@@ -446,5 +447,6 @@ EOF
         end
       end
     end
+    # rubocop: enable Metrics/ClassLength
   end
 end

--- a/lib/branch_io_cli/version.rb
+++ b/lib/branch_io_cli/version.rb
@@ -1,3 +1,3 @@
 module BranchIOCLI
-  VERSION = "0.5.4"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Added a report command that will clean and build a project or workspace, generating a verbose log with additional diagnostic info, suitable for generating a support ticket.

```bash
[jdee@Jimmy-Dees-MacBookPro BranchPluginExample (reporting)]$ bundle exec branch_io report -t

branch_io report v. 0.6.0

Configuration:

Xcode workspace: /Users/jdee/github/BranchMetrics/branch_io_cli/examples/BranchPluginExample/BranchPluginExample.xcworkspace
Xcode project: (none)
Scheme: BranchPluginExample
Target: (none)
Configuration: (none)
Podfile: /Users/jdee/github/BranchMetrics/branch_io_cli/examples/BranchPluginExample/Podfile
Cartfile: (none)
Clean: true
Report path: ./report.txt

Cleaning
Building
Done ✅
Report generated in ./report.txt
```