### PR TITLE
Add info to report

### DIFF
--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/BranchMetrics/branch_io_cli'
   spec.license       = 'MIT'
 
+  spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'cocoapods-core'
   spec.add_dependency 'commander'
   spec.add_dependency 'pattern_patch'

--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/BranchMetrics/branch_io_cli'
   spec.license       = 'MIT'
 
+  spec.add_dependency 'cocoapods-core'
   spec.add_dependency 'commander'
   spec.add_dependency 'pattern_patch'
   spec.add_dependency 'plist'

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,3 +1,5 @@
+require 'cocoapods-core'
+
 module BranchIOCLI
   module Commands
     class ReportCommand < Command
@@ -48,9 +50,8 @@ module BranchIOCLI
 
       def branch_version
         if config_helper.podfile_path && File.exist?("#{config_helper.podfile_path}.lock")
-          podfile_lock = File.read "#{config_helper.podfile_path}.lock"
-          matches = %r{Branch/Core \(= (\d+\.\d+\.\d+)\)}m.match podfile_lock
-          return matches[1] if matches
+          podfile_lock = Pod::Lockfile.from_file Pathname.new "#{config_helper.podfile_path}.lock"
+          return podfile_lock.version "Branch"
         elsif config_helper.cartfile_path && File.exist?("#{config_helper.cartfile_path}.resolved")
           cartfile_resolved = File.read "#{config_helper.cartfile_path}.resolved"
           matches = /ios-branch-deep-linking" "(\d+\.\d+\.\d+)"/m.match cartfile_resolved

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,4 +1,5 @@
-require 'cocoapods-core'
+require "cocoapods-core"
+require "cfpropertylist"
 
 module BranchIOCLI
   module Commands
@@ -66,6 +67,14 @@ module BranchIOCLI
           # github "BranchMetrics/iOS-Deferred-Deep-Linking-SDK/"
           matches = %r{(ios-branch-deep-linking|iOS-Deferred-Deep-Linking-SDK)/?" "(\d+\.\d+\.\d+)"}m.match cartfile_resolved
           return matches[2] if matches
+        elsif config_helper.xcodeproj
+          framework = config_helper.xcodeproj.frameworks_group.files.find { |f| f.path =~ /Branch.framework$/ }
+          return nil unless framework
+          framework_path = framework.real_path
+          info_plist_path = File.join framework_path.to_s, "Info.plist"
+          raw_info_plist = CFPropertyList::List.new file: info_plist_path
+          info_plist = CFPropertyList.native_types raw_info_plist.value
+          return info_plist["CFBundleVersion"]
         end
         nil
       end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -54,8 +54,18 @@ module BranchIOCLI
           return podfile_lock.version "Branch"
         elsif config_helper.cartfile_path && File.exist?("#{config_helper.cartfile_path}.resolved")
           cartfile_resolved = File.read "#{config_helper.cartfile_path}.resolved"
-          matches = /ios-branch-deep-linking" "(\d+\.\d+\.\d+)"/m.match cartfile_resolved
-          return matches[1] if matches
+
+          # Matches:
+          # git "https://github.com/BranchMetrics/ios-branch-deep-linking"
+          # git "https://github.com/BranchMetrics/ios-branch-deep-linking/"
+          # git "https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK"
+          # git "https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK/"
+          # github "BranchMetrics/ios-branch-deep-linking"
+          # github "BranchMetrics/ios-branch-deep-linking/"
+          # github "BranchMetrics/iOS-Deferred-Deep-Linking-SDK"
+          # github "BranchMetrics/iOS-Deferred-Deep-Linking-SDK/"
+          matches = %r{(ios-branch-deep-linking|iOS-Deferred-Deep-Linking-SDK)/?" "(\d+\.\d+\.\d+)"}m.match cartfile_resolved
+          return matches[2] if matches
         end
         nil
       end

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -271,7 +271,7 @@ EOF
 
           # Try to find first a workspace, then a project
           all_workspace_paths = Dir[File.expand_path(File.join(".", "**/*.xcworkspace"))]
-                                .reject { |w| w =~ %r{/project.pbxproj$} }
+                                .reject { |w| w =~ %r{/project.xcworkspace$} }
                                 .select do |p|
             valid = true
             Pathname.new(p).each_filename do |f|


### PR DESCRIPTION
In the `report` command:

- Use `cocoapods-core` to parse Podfile.lock.
- Recognize more Carthage formats.
- Report version of Branch.framework in case of direct integration.

Also fixed a bug with workspace detection.