### PR TITLE
Improve SDK version reporting

### DIFF
--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -43,7 +43,7 @@ module BranchIOCLI
         cmd = "xcodebuild"
         cmd = "#{cmd} -scheme #{config_helper.scheme}" if config_helper.scheme
         cmd = "#{cmd} -workspace #{config_helper.workspace_path}" if config_helper.workspace_path
-        cmd = "#{cmd} -project #{config_helper.xcodeproj_path}" if config_helper.xcodeproj_path
+        cmd = "#{cmd} -project #{config_helper.xcodeproj_path}" if config_helper.xcodeproj_path && !config_helper.workspace_path
         cmd = "#{cmd} -target #{config_helper.target}" if config_helper.target
         cmd = "#{cmd} -configuration #{config_helper.configuration}" if config_helper.configuration
         cmd
@@ -76,6 +76,7 @@ module BranchIOCLI
           info_plist = CFPropertyList.native_types raw_info_plist.value
           return info_plist["CFBundleVersion"]
         end
+        # TODO: Detect if the Branch SDK source is included in the project.
         nil
       end
 

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -302,6 +302,13 @@ EOF
               if path =~ /\.xcworkspace$/
                 @workspace = Xcodeproj::Workspace.new_from_xcworkspace path
                 @workspace_path = path
+
+                # Pass --workspace and --xcodeproj to override this inference.
+                if @workspace.file_references.count > 0 && @workspace.file_references.first.path =~ /\.xcodeproj$/
+                  @xcodeproj_path = File.expand_path "../#{@workspace.file_references.first.path}", @workspace_path
+                  @xcodeproj = Xcodeproj::Project.open @xcodeproj_path
+                end
+
                 return
               elsif path =~ /\.xcodeproj$/
                 @xcodeproj = Xcodeproj::Project.open path


### PR DESCRIPTION
Flesh out reporting of SDK version. Can find the version in `Podfile.lock`, `Cartfile.resolved`, `Branch.framework/Info.plist` or `BNCConfig.m`, depending how the SDK is integrated. The output in `report.txt` will resemble one of the following:

```
Branch SDK v. 0.21.0 [Podfile.lock]
```

```
Branch SDK v. 0.21.0 [Cartfile.resolved]
```

```
Branch SDK v. 0.21.0 [Branch.framework/Info.plist]
```

```
Branch SDK v. 0.21.0 [BNCConfig.m]
```