### PR TITLE
Add --carthage-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ command, respectively, available in your path.
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|
+|--carthage-command <command>|Command to use when installing from Carthage (default: update --platform ios)|
 |--frameworks AdSupport,CoreSpotlight,SafariServices|Comma-separated list of system frameworks to add to the project|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|
 |--[no-]validate|Validate Universal Link configuration (default: yes)|

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ branch_io setup -D myapp.app.link,example.com,www.example.com
 branch_io setup --no-pod-repo-update
 ```
 
+##### Install using carthage bootstrap
+
+```bash
+branch_io --carthage-command "bootstrap --no-use-binaries"
+```
+
 ### Validate command
 
 ```bash

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -12,7 +12,7 @@ _branch_io_complete()
     global_opts="-h --help -t --trace -v --version"
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile"
+    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command"
     # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
     setup_opts="$setup_opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.zsh
+++ b/lib/assets/completions/completion.zsh
@@ -5,7 +5,7 @@ _branch_io_complete() {
   word="$1"
   opts="-h --help -t --trace -v --version"
   opts="$opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile"
+  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command"
   # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
   opts="$opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -82,6 +82,7 @@ EOF
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"
         c.option "--podfile /path/to/Podfile", String, "Path to the Podfile for the project"
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
+        c.option "--carthage-command <command>", String, "Command to run when installing from Carthage (default: update --platform ios)"
         c.option "--frameworks AdSupport,CoreSpotlight,SafariServices", Array, "Comma-separated list of system frameworks to add to the project"
 
         c.option "--[no-]pod-repo-update", "Update the local podspec repo before installing (default: yes)"
@@ -104,7 +105,8 @@ EOF
             force: false,
             add_sdk: true,
             patch_source: true,
-            commit: false
+            commit: false,
+            carthage_command: "update --platform ios"
           )
           Commands::SetupCommand.new(options).run!
         end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -96,6 +96,7 @@ EOF
         c.example "Use both live and test keys", "branch_io setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link"
         c.example "Use custom or non-Branch domains", "branch_io setup -D myapp.app.link,example.com,www.example.com"
         c.example "Avoid pod repo update", "branch_io setup --no-pod-repo-update"
+        c.example "Install using carthage bootstrap", "branch_io --carthage-command \"bootstrap --no-use-binaries\""
 
         c.action do |args, options|
           options.default(

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -26,6 +26,7 @@ module BranchIOCLI
         attr_reader :all_domains
         attr_reader :podfile_path
         attr_reader :cartfile_path
+        attr_reader :carthage_command
         attr_reader :target
         attr_reader :uri_scheme
         attr_reader :pod_repo_update
@@ -72,6 +73,7 @@ module BranchIOCLI
 
           # If --podfile is present or a Podfile was found, don't look for a Cartfile.
           validate_buildfile_path options.cartfile, "Cartfile" if @sdk_integration_mode.nil? && options.add_sdk
+          @carthage_command = options.carthage_command if @sdk_integration_mode == :carthage
 
           validate_sdk_addition options
 
@@ -133,6 +135,7 @@ EOF
 <%= color('URI scheme:', BOLD) %> #{@uri_scheme || '(none)'}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
+<%= color('Carthage command:', BOLD) %> #{@carthage_command || '(none)'}
 <%= color('Pod repo update:', BOLD) %> #{@pod_repo_update.inspect}
 <%= color('Validate:', BOLD) %> #{@validate.inspect}
 <%= color('Force:', BOLD) %> #{@force.inspect}
@@ -498,6 +501,7 @@ EOF
             @podfile_path = File.expand_path "../Podfile", @xcodeproj_path
           when :carthage
             @cartfile_path = File.expand_path "../Cartfile", @xcodeproj_path
+            @carthage_command = options.carthage_command
           end
         end
       end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -725,7 +725,7 @@ EOF
 
         # 2. carthage update
         Dir.chdir(File.dirname(cartfile_path)) do
-          system "carthage update --platform ios"
+          system "carthage #{ConfigurationHelper.carthage_command}"
         end
 
         # 3. Add Cartfile and Cartfile.resolved to commit (in case :commit param specified)
@@ -864,7 +864,7 @@ EOF
 
         # 2. carthage update
         Dir.chdir(File.dirname(cartfile_path)) do
-          system "carthage update --platform ios"
+          system "carthage #{ConfigurationHelper.carthage_command}"
         end
 
         # 3. Add Cartfile and Cartfile.resolved to commit (in case :commit param specified)

--- a/lib/branch_io_cli/version.rb
+++ b/lib/branch_io_cli/version.rb
@@ -1,3 +1,3 @@
 module BranchIOCLI
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
When installing via Carthage, by default the command used is `update --platform ios`. This can now be overridden using the `--carthage-command` option, e.g.

```bash
branch_io setup --carthage-command "bootstrap --no-use-binaries"
```