### PR TITLE
More report data

### DIFF
--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -137,11 +137,12 @@ module BranchIOCLI
 
         version = branch_version
         if version
-          header = "#{header}\nBranch SDK v. #{version}"
+          header = "#{header}\nBranch SDK v. #{version}\n"
         else
-          header = "Branch SDK not found"
+          header = "Branch SDK not found.\n"
         end
-        "#{header}\n"
+
+        header
       end
     end
   end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -74,6 +74,7 @@ module BranchIOCLI
         return nil unless config_helper.podfile_path && File.exist?("#{config_helper.podfile_path}.lock")
         podfile_lock = Pod::Lockfile.from_file Pathname.new "#{config_helper.podfile_path}.lock"
         version = podfile_lock.version "Branch"
+
         version ? "#{version} [Podfile.lock]" : nil
       end
 
@@ -122,6 +123,11 @@ module BranchIOCLI
 
       def report_header
         header = `xcodebuild -version`
+
+        if config_helper.podfile_path && File.exist?("#{config_helper.podfile_path}.lock")
+          podfile_lock = Pod::Lockfile.from_file Pathname.new "#{config_helper.podfile_path}.lock"
+          header = "#{header}\nUsing CocoaPods v. #{podfile_lock.cocoapods_version}\n"
+        end
 
         podfile_requirement = requirement_from_podfile
         header = "#{header}\nFrom Podfile:\n#{podfile_requirement}\n" if podfile_requirement

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -266,6 +266,12 @@ EOF
               path = options.xcodeproj
               @xcodeproj = Xcodeproj::Project.open options.xcodeproj
               @xcodeproj_path = options.xcodeproj
+            else
+              # Pass --workspace and --xcodeproj to override this inference.
+              if @workspace && @workspace.file_references.count > 0 && @workspace.file_references.first.path =~ /\.xcodeproj$/
+                @xcodeproj_path = File.expand_path "../#{@workspace.file_references.first.path}", @workspace_path
+                @xcodeproj = Xcodeproj::Project.open @xcodeproj_path
+              end
             end
             return if @workspace || @xcodeproj
           rescue StandardError => e


### PR DESCRIPTION
Report CocoaPods version whenever Podfile.lock found (whether Branch pod is present or not).

Infer location of xcodeproj in all cases when a workspace is present (previously only when workspace location inferred).