### PR TITLE
Install build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Before using this command, make sure to set up your app in the [Branch Dashboard
 - Domain name(s) used for Branch links
 - Location of your Xcode project (may be inferred in simple projects)
 
-To use the `--commit` option, you must have the `git` command available in your path.
-
-To add the SDK with CocoaPods or Carthage, you must have the `pod` or `carthage`
-command, respectively, available in your path.
+If using the `--commit` option, `git` is required. If not using `--no-add-sdk`,
+the `pod` or `carthage` command may be required. If not found, the CLI will
+offer to install and set up these command-line tools for you. Alternately, you can arrange
+that the relevant commands are available in your `PATH`.
 
 #### Options
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -58,10 +58,10 @@ for details. To use the <%= color('setup', BOLD) %> command, you need:
 - Domain name(s) used for Branch links
 - Location of your Xcode project (may be inferred in simple projects)
 
-To use the <%= color('--commit', BOLD) %> option, you must have the <%= color('git', BOLD) %> command available in your path.
-
-To add the SDK with CocoaPods or Carthage, you must have the <%= color('pod', BOLD) %> or <%= color('carthage', BOLD) %>
-command, respectively, available in your path.
+If using the <%= color('--commit', BOLD) %> option, <%= color('git', BOLD) %> is required. If not using <%= color('--no-add-sdk', BOLD) %>,
+the <%= color('pod', BOLD) %> or <%= color('carthage', BOLD) %> command may be required. If not found, the CLI will
+offer to install and set up these command-line tools for you. Alternately, you can arrange
+that the relevant commands are available in your <%= color('PATH', BOLD) %>.
 
 All parameters are optional. A live key or test key, or both is required, as well
 as at least one domain. Specify <%= color('--live-key', BOLD) %>, <%= color('--test-key', BOLD) %> or both and <%= color('--app-link-subdomain', BOLD) %>,

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -77,6 +77,8 @@ module BranchIOCLI
 
           validate_sdk_addition options
 
+          BranchHelper.verify_git if @commit
+
           print_setup_configuration
         end
 

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -1050,6 +1050,27 @@ EOF
         system_command "brew install carthage"
       end
 
+      def verify_git
+        return unless ConfigurationHelper.commit
+
+        git_cmd = `which git`
+        return unless git_cmd.empty?
+
+        xcode_select_path = `which xcode-select`
+        if xcode_select_path.empty?
+          say "'git' command not available in PATH and 'xcode-select' command not available in PATH to install 'git'."
+          exit(-1)
+        end
+
+        install = ask "'git' command not available in PATH. Install Xcode command-line tools (requires password) (Y/n)? "
+        if install.downcase =~ /^n/
+          say "Please install Xcode command tools or leave out the --commit option to continue."
+          exit(-1)
+        end
+
+        system_command "xcode-select --install"
+      end
+
       def system_command(command)
         # TODO: Not working well with bundle exec atm.
         say "<%= color(\"$ #{command}\", BOLD) %>"


### PR DESCRIPTION
If the `git`, `pod` or `carthage` command is needed and not found, the CLI will prompt to install `git` using `xcode-select --install`, `carthage` using `brew install carthage` and `pod` using `[sudo] gem install cocoapods`. If the `cocoapods` gem is installed, the `pod setup` command will also be run to initialize/verify the master podspec repo.