### PR TITLE
Improve cocoapods install

### DIFF
--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -21,6 +21,10 @@ module BranchIOCLI
           # TODO: Write out command-line options or configuration from helper
           report.write "#{report_header}\n"
 
+          show_build_settings_cmd = "#{base_xcodebuild_cmd} -showBuildSettings"
+          report.write "$ #{show_build_settings_cmd}\n\n"
+          report.write `#{show_build_settings_cmd}`
+
           if config_helper.clean
             say "Cleaning"
             clean_cmd = "#{base_xcodebuild_cmd} clean"
@@ -39,7 +43,7 @@ module BranchIOCLI
       end
 
       def base_xcodebuild_cmd
-        cmd = "xcodebuild"
+        cmd = "xcodebuild -sdk iphonesimulator"
         cmd = "#{cmd} -scheme #{config_helper.scheme}" if config_helper.scheme
         cmd = "#{cmd} -workspace #{config_helper.workspace_path}" if config_helper.workspace_path
         cmd = "#{cmd} -project #{config_helper.xcodeproj_path}" if config_helper.xcodeproj_path && !config_helper.workspace_path

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,5 +1,4 @@
 require "cocoapods-core"
-require "cfpropertylist"
 
 module BranchIOCLI
   module Commands
@@ -103,6 +102,8 @@ module BranchIOCLI
         framework_path = framework.real_path
         info_plist_path = File.join framework_path.to_s, "Info.plist"
         return nil unless File.exist? info_plist_path
+
+        require "cfpropertylist"
 
         raw_info_plist = CFPropertyList::List.new file: info_plist_path
         info_plist = CFPropertyList.native_types raw_info_plist.value

--- a/lib/branch_io_cli/commands/setup_command.rb
+++ b/lib/branch_io_cli/commands/setup_command.rb
@@ -29,11 +29,10 @@ module BranchIOCLI
           helper.add_direct options
         end
 
-        target_name = options.target # may be nil
         is_app_target = !config_helper.target.extension_target_type?
 
         if is_app_target && options.validate &&
-           !helper.validate_team_and_bundle_ids_from_aasa_files(xcodeproj, target_name, @domains)
+           !helper.validate_team_and_bundle_ids_from_aasa_files(@domains)
           say "Universal Link configuration failed validation."
           helper.errors.each { |error| say " #{error}" }
           return unless options.force
@@ -42,14 +41,14 @@ module BranchIOCLI
         end
 
         # the following calls can all raise IOError
-        helper.add_keys_to_info_plist xcodeproj, target_name, @keys
-        helper.add_branch_universal_link_domains_to_info_plist xcodeproj, target_name, @domains if is_app_target
+        helper.add_keys_to_info_plist @keys
+        helper.add_branch_universal_link_domains_to_info_plist @domains if is_app_target
         helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present
 
-        new_path = helper.add_universal_links_to_project xcodeproj, target_name, @domains, false if is_app_target
+        new_path = helper.add_universal_links_to_project @domains, false if is_app_target
         `git add #{new_path}` if options.commit && new_path
 
-        helper.add_system_frameworks xcodeproj, target_name, options.frameworks unless options.frameworks.nil? || options.frameworks.empty?
+        config_helper.target.add_system_frameworks options.frameworks unless options.frameworks.nil? || options.frameworks.empty?
 
         xcodeproj.save
 

--- a/lib/branch_io_cli/commands/validate_command.rb
+++ b/lib/branch_io_cli/commands/validate_command.rb
@@ -7,17 +7,10 @@ module BranchIOCLI
       end
 
       def run!
-        # raises
-        xcodeproj = config_helper.xcodeproj
-
         valid = true
 
         unless options.domains.nil? || options.domains.empty?
-          domains_valid = helper.validate_project_domains(
-            options.domains,
-            xcodeproj,
-            options.target
-          )
+          domains_valid = helper.validate_project_domains(options.domains)
 
           if domains_valid
             say "Project domains match :domains parameter: ✅"
@@ -29,7 +22,7 @@ module BranchIOCLI
           valid &&= domains_valid
         end
 
-        configuration_valid = helper.validate_team_and_bundle_ids_from_aasa_files xcodeproj, options.target
+        configuration_valid = helper.validate_team_and_bundle_ids_from_aasa_files
         unless configuration_valid
           say "Universal Link configuration failed validation."
           helper.errors.each { |error| say " #{error}" }

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -435,7 +435,7 @@ module BranchIOCLI
 
         if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
           # method already present
-          init_session_text = ConfigurationHelper.keys.count <= 1 ? "" : <<EOF
+          init_session_text = ConfigurationHelper.keys.count <= 1 && !has_multiple_info_plists? ? "" : <<EOF
         #if DEBUG
             Branch.setUseTestBranchKey(true)
         #endif
@@ -464,7 +464,7 @@ EOF
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 EOF
 
-          if ConfigurationHelper.keys.count > 1
+          if ConfigurationHelper.keys.count > 1 && !has_multiple_info_plists?
             method_text += <<EOF
         #if DEBUG
           Branch.setUseTestBranchKey(true)
@@ -497,7 +497,7 @@ EOF
 
         if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
           # method exists. patch it.
-          init_session_text = ConfigurationHelper.keys.count <= 1 ? "" : <<EOF
+          init_session_text = ConfigurationHelper.keys.count <= 1 && !has_multiple_info_plists? ? "" : <<EOF
 #ifdef DEBUG
     [Branch setUseTestBranchKey:YES];
 #endif // DEBUG
@@ -524,7 +524,7 @@ EOF
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 EOF
 
-          if ConfigurationHelper.keys.count > 1
+          if ConfigurationHelper.keys.count > 1 && !has_multiple_info_plists?
             method_text += <<EOF
 #ifdef DEBUG
     [Branch setUseTestBranchKey:YES];

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -898,7 +898,7 @@ EOF
 
         # Now the current framework is in framework_path
 
-        say "Adding to #{@xcodeproj_path}"
+        say "Adding to #{ConfigurationHelper.xcodeproj_path}"
 
         # Add as a dependency in the Frameworks group
         framework = frameworks_group.new_file "Branch.framework" # relative to frameworks_group.real_path

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -91,7 +91,7 @@ module BranchIOCLI
 
         raise "Info.plist not found for configuration #{configuration}" if info_plist_path.nil?
 
-        project_parent = File.dirname project.path
+        project_parent = File.dirname ConfigurationHelper.xcodeproj_path
 
         info_plist_path = File.expand_path info_plist_path, project_parent
 

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -435,7 +435,7 @@ module BranchIOCLI
 
         if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
           # method already present
-          init_session_text = ConfigurationHelper.keys.count <= 1 && !has_multiple_info_plists? ? "" : <<EOF
+          init_session_text = ConfigurationHelper.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
         #if DEBUG
             Branch.setUseTestBranchKey(true)
         #endif
@@ -497,7 +497,7 @@ EOF
 
         if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
           # method exists. patch it.
-          init_session_text = ConfigurationHelper.keys.count <= 1 && !has_multiple_info_plists? ? "" : <<EOF
+          init_session_text = ConfigurationHelper.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
 #ifdef DEBUG
     [Branch setUseTestBranchKey:YES];
 #endif // DEBUG

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -1014,17 +1014,23 @@ EOF
         pod_cmd = `which pod`
         return unless pod_cmd.empty?
 
+        gem_cmd = `which gem`
+        if gem_cmd.empty?
+          say "'pod' command not available in PATH and 'gem' command not available in PATH to install cocoapods."
+          exit(-1)
+        end
+
         install = ask "'pod' command not available in PATH. Install cocoapods (may require a sudo password) (Y/n)? "
         if install.downcase =~ /^n/
           say "Please install cocoapods or use --no-add-sdk to continue."
           exit(-1)
         end
 
-        gem_home = ENV["GEM_HOME"] # TODO: If this is not set, something is seriously wrong. What to do?
-        if File.writable? gem_home
+        gem_home = ENV["GEM_HOME"]
+        if gem_home && File.writable? gem_home
           system_command "gem install cocoapods"
         else
-          system_command "sudo gem install cocoapods" # TODO: this will come out bundle exec sudo gem install...
+          system_command "sudo gem install cocoapods"
         end
 
         # Ensure master podspec repo is set up (will update if it exists).

--- a/spec/ios_helper_spec.rb
+++ b/spec/ios_helper_spec.rb
@@ -215,54 +215,42 @@ describe BranchIOCLI::Helper::IOSHelper do
 
   describe '#validate_team_and_bundle_ids_from_aasa_files' do
     it 'only succeeds if all domains are valid' do
-      project = double "project"
-
       # No domains in project. Just validating what's passed in.
       expect(instance).to receive(:domains_from_project) { [] }
       # example.com is valid
       expect(instance).to receive(:validate_team_and_bundle_ids)
-        .with(project, nil, "example.com", "Release") { true }
+        .with("example.com", "Release") { true }
       # www.example.com is not valid
       expect(instance).to receive(:validate_team_and_bundle_ids)
-        .with(project, nil, "www.example.com", "Release") { false }
+        .with("www.example.com", "Release") { false }
 
       valid = instance.validate_team_and_bundle_ids_from_aasa_files(
-        project,
-        nil,
         %w{example.com www.example.com}
       )
       expect(valid).to be false
     end
 
     it 'succeeds if all domains are valid' do
-      project = double "project"
-
       # No domains in project. Just validating what's passed in.
       expect(instance).to receive(:domains_from_project) { [] }
       # example.com is valid
       expect(instance).to receive(:validate_team_and_bundle_ids)
-        .with(project, nil, "example.com", "Release") { true }
+        .with("example.com", "Release") { true }
       # www.example.com is not valid
       expect(instance).to receive(:validate_team_and_bundle_ids)
-        .with(project, nil, "www.example.com", "Release") { true }
+        .with("www.example.com", "Release") { true }
 
       valid = instance.validate_team_and_bundle_ids_from_aasa_files(
-        project,
-        nil,
         %w{example.com www.example.com}
       )
       expect(valid).to be true
     end
 
     it 'fails if no domains specified and no domains in project' do
-      project = double "project"
-
       # No domains in project. Just validating what's passed in.
       expect(instance).to receive(:domains_from_project) { [] }
 
       valid = instance.validate_team_and_bundle_ids_from_aasa_files(
-        project,
-        nil,
         []
       )
       expect(valid).to be false


### PR DESCRIPTION
- Check for availability of `gem` command when installing `cocoapods` and account for system Ruby-ness.
- Handle different Info.plist files for different configurations.
- Report builds use iphonesimulator in order to avoid code-signing issues.
- Reports include output of `xcodebuild -showBuildSettings`.
- Several small fixes.