### PR TITLE
Improved handling of shell commands

### DIFF
--- a/lib/branch_io_cli.rb
+++ b/lib/branch_io_cli.rb
@@ -1,4 +1,5 @@
 require "branch_io_cli/cli"
 require "branch_io_cli/commands"
+require "branch_io_cli/core_ext"
 require "branch_io_cli/helper"
 require "branch_io_cli/version"

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,5 +1,4 @@
 require "cocoapods-core"
-require "open3"
 
 module BranchIOCLI
   module Commands

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -1,4 +1,5 @@
 require "cocoapods-core"
+require "open3"
 
 module BranchIOCLI
   module Commands
@@ -17,28 +18,24 @@ module BranchIOCLI
         end
 
         File.open config_helper.report_path, "w" do |report|
-          report.write "Branch.io Xcode build report v #{VERSION}\n\n"
+          report.write "Branch.io Xcode build report v #{VERSION} #{DateTime.now}\n\n"
           # TODO: Write out command-line options or configuration from helper
           report.write "#{report_header}\n"
 
-          show_build_settings_cmd = "#{base_xcodebuild_cmd} -showBuildSettings"
-          report.write "$ #{show_build_settings_cmd}\n\n"
-          report.write `#{show_build_settings_cmd}`
+          report.report_command "#{base_xcodebuild_cmd} -showBuildSettings"
 
           if config_helper.clean
             say "Cleaning"
-            clean_cmd = "#{base_xcodebuild_cmd} clean"
-            report.write "$ #{clean_cmd}\n\n"
-            report.write `#{clean_cmd}`
+            report.report_command "#{base_xcodebuild_cmd} clean"
           end
 
           say "Building"
-          build_cmd = "#{base_xcodebuild_cmd} -verbose"
-          report.write "$ #{build_cmd}\n\n"
-          report.write `#{build_cmd}`
+          report.report_command "#{base_xcodebuild_cmd} -verbose"
 
           say "Done ✅"
         end
+        @report = nil
+
         say "Report generated in #{config_helper.report_path}"
       end
 

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -22,6 +22,7 @@ module BranchIOCLI
           # TODO: Write out command-line options or configuration from helper
           report.write "#{report_header}\n"
 
+          report.report_command "#{base_xcodebuild_cmd} -list"
           report.report_command "#{base_xcodebuild_cmd} -showBuildSettings"
 
           if config_helper.clean

--- a/lib/branch_io_cli/core_ext.rb
+++ b/lib/branch_io_cli/core_ext.rb
@@ -1,0 +1,1 @@
+require "branch_io_cli/core_ext/io.rb"

--- a/lib/branch_io_cli/core_ext/io.rb
+++ b/lib/branch_io_cli/core_ext/io.rb
@@ -1,0 +1,20 @@
+require "open3"
+
+class IO
+  def report_command(command)
+    if self == STDOUT
+      # TODO: Improve this.
+      say "<%= color('$ #{command}', BOLD) %>\n\n"
+    else
+      write "$ #{command}\n\n"
+    end
+
+    Open3.popen2e(command) do |stdin, output, thread|
+      write output.read
+    end
+    write "\n\n"
+
+    status = $?.exitstatus
+    write "#{command} returned #{status}." unless status == 0
+  end
+end

--- a/lib/branch_io_cli/core_ext/io.rb
+++ b/lib/branch_io_cli/core_ext/io.rb
@@ -3,18 +3,26 @@ require "open3"
 class IO
   def report_command(command)
     if self == STDOUT
-      # TODO: Improve this.
+      # TODO: Improve this?
       say "<%= color('$ #{command}', BOLD) %>\n\n"
     else
       write "$ #{command}\n\n"
     end
 
     Open3.popen2e(command) do |stdin, output, thread|
-      write output.read
-    end
-    write "\n\n"
+      # output is stdout and stderr merged
+      while (line = output.gets)
+        puts line
+      end
 
-    status = $?.exitstatus
-    write "#{command} returned #{status}." unless status == 0
+      status = thread.value
+      if status == 0
+        write "Success.\n\n"
+      else
+        write "#{status}\n\n"
+      end
+
+      return status
+    end
   end
 end

--- a/lib/branch_io_cli/helper.rb
+++ b/lib/branch_io_cli/helper.rb
@@ -1,2 +1,3 @@
 require "branch_io_cli/helper/branch_helper"
 require "branch_io_cli/helper/configuration_helper"
+require "branch_io_cli/helper/methods"

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -1,0 +1,9 @@
+module BranchIOCLI
+  module Helper
+    module Methods
+      def report_command(command)
+        STDOUT.report_command command
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use `open3` to capture both stdout and stderr from shell commands. Previously backticks were used, which only capture stdout. Errors were not being included with the `report` command, only reported to the terminal.

This was refactored into an `IO#report_command` method for uniformity when shelling out.