### PR TITLE
Shell command error handling

### DIFF
--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -34,7 +34,6 @@ module BranchIOCLI
 
           say "Done ✅"
         end
-        @report = nil
 
         say "Report generated in #{config_helper.report_path}"
       end

--- a/lib/branch_io_cli/commands/setup_command.rb
+++ b/lib/branch_io_cli/commands/setup_command.rb
@@ -3,8 +3,6 @@ require "branch_io_cli/helper/methods"
 module BranchIOCLI
   module Commands
     class SetupCommand < Command
-      include Helper::Methods
-
       def initialize(options)
         super
         config_helper.validate_setup_options options

--- a/lib/branch_io_cli/commands/setup_command.rb
+++ b/lib/branch_io_cli/commands/setup_command.rb
@@ -1,6 +1,10 @@
+require "branch_io_cli/helper/methods"
+
 module BranchIOCLI
   module Commands
     class SetupCommand < Command
+      include Helper::Methods
+
       def initialize(options)
         super
         config_helper.validate_setup_options options
@@ -46,7 +50,7 @@ module BranchIOCLI
         helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present
 
         new_path = helper.add_universal_links_to_project @domains, false if is_app_target
-        `git add #{new_path}` if options.commit && new_path
+        sh "git add #{new_path}" if options.commit && new_path
 
         config_helper.target.add_system_frameworks options.frameworks unless options.frameworks.nil? || options.frameworks.empty?
 
@@ -58,7 +62,7 @@ module BranchIOCLI
 
         changes = helper.changes.to_a.map { |c| Pathname.new(File.expand_path(c)).relative_path_from(Pathname.pwd).to_s }
 
-        `git commit #{changes.join(" ")} -m '[branch_io_cli] Branch SDK integration'`
+        sh "git commit -qm '[branch_io_cli] Branch SDK integration' #{changes.join(' ')}"
       end
       # rubocop: enable Metrics/PerceivedComplexity
     end

--- a/lib/branch_io_cli/core_ext/io.rb
+++ b/lib/branch_io_cli/core_ext/io.rb
@@ -33,8 +33,8 @@ end
 #
 # :command: [String] a shell command to execute and report
 def STDOUT.report_command(command)
-  # TODO: Improve this?
-  say "<%= color('$ #{command}', BOLD) %>\n\n"
+  # TODO: Improve this implementation?
+  say "<%= color(%q{$ #{command}}, BOLD) %>\n\n"
   # May also write to stderr
   # Could try system "#{command} 2>&1", but that might depend on the shell.
   system command
@@ -45,4 +45,5 @@ def STDOUT.report_command(command)
   else
     write "#{status}\n\n"
   end
+  status
 end

--- a/lib/branch_io_cli/helper.rb
+++ b/lib/branch_io_cli/helper.rb
@@ -1,3 +1,2 @@
 require "branch_io_cli/helper/branch_helper"
 require "branch_io_cli/helper/configuration_helper"
-require "branch_io_cli/helper/methods"

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -813,7 +813,7 @@ EOF
         podfile_pathname = Pathname.new(podfile_path).relative_path_from Pathname.pwd
         add_change pods_folder_path
         add_change workspace_path
-        `git add #{podfile_pathname} #{podfile_pathname}.lock #{pods_folder_path} #{workspace_path}` if options.commit
+        sh "git add #{podfile_pathname} #{podfile_pathname}.lock #{pods_folder_path} #{workspace_path}" if options.commit
       end
 
       def add_carthage(options)
@@ -859,7 +859,7 @@ EOF
         carthage_folder_path = Pathname.new(File.expand_path("../Carthage", cartfile_path)).relative_path_from(Pathname.pwd)
         cartfile_pathname = Pathname.new(cartfile_path).relative_path_from Pathname.pwd
         add_change carthage_folder_path
-        `git add #{cartfile_pathname} #{cartfile_pathname}.resolved #{carthage_folder_path}` if options.commit
+        sh "git add #{cartfile_pathname} #{cartfile_pathname}.resolved #{carthage_folder_path}" if options.commit
       end
 
       def add_direct(options)
@@ -923,7 +923,7 @@ EOF
 
         add_change ConfigurationHelper.xcodeproj_path
         add_change framework_path
-        `git add #{framework_path}` if options.commit
+        sh "git add #{framework_path}" if options.commit
 
         say "Done. ✅"
       end
@@ -957,7 +957,7 @@ EOF
 
         # 5. If so, add the Pods folder to the commit (in case :commit param specified)
         add_change pods_folder_path
-        `git add #{pods_folder_path}` if options.commit
+        sh "git add #{pods_folder_path}" if options.commit
 
         true
       end
@@ -1004,7 +1004,7 @@ EOF
 
         # 7. If so, add the Carthage folder to the commit (in case :commit param specified)
         add_change carthage_folder_path
-        `git add #{carthage_folder_path}` if options.commit
+        sh "git add #{carthage_folder_path}" if options.commit
 
         true
       end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -793,7 +793,7 @@ EOF
         install_command = "pod install"
         install_command += " --repo-update" if options.pod_repo_update
         Dir.chdir(File.dirname(podfile_path)) do
-          report_command "pod init"
+          sh "pod init"
           apply_patch(
             files: podfile_path,
             regexp: /^(\s*)# Pods for #{ConfigurationHelper.target.name}$/,
@@ -801,7 +801,7 @@ EOF
             text: "\n\\1pod \"Branch\"",
             global: false
           )
-          report_command install_command
+          sh install_command
         end
 
         add_change podfile_path
@@ -830,7 +830,7 @@ EOF
 
         # 2. carthage update
         Dir.chdir(File.dirname(cartfile_path)) do
-          report_command "carthage #{ConfigurationHelper.carthage_command}"
+          sh "carthage #{ConfigurationHelper.carthage_command}"
         end
 
         # 3. Add Cartfile and Cartfile.resolved to commit (in case :commit param specified)
@@ -943,7 +943,7 @@ EOF
         command += ' --repo-update' if options.pod_repo_update
 
         Dir.chdir(File.dirname(podfile_path)) do
-          report_command command
+          sh command
         end
 
         # 3. Add Podfile and Podfile.lock to commit (in case :commit param specified)
@@ -973,7 +973,7 @@ EOF
 
         # 2. carthage update
         Dir.chdir(File.dirname(cartfile_path)) do
-          report_command "carthage #{ConfigurationHelper.carthage_command}"
+          sh "carthage #{ConfigurationHelper.carthage_command}"
         end
 
         # 3. Add Cartfile and Cartfile.resolved to commit (in case :commit param specified)
@@ -1031,13 +1031,13 @@ EOF
 
         gem_home = ENV["GEM_HOME"]
         if gem_home && File.writable?(gem_home)
-          report_command "gem install cocoapods"
+          sh "gem install cocoapods"
         else
-          report_command "sudo gem install cocoapods"
+          sh "sudo gem install cocoapods"
         end
 
         # Ensure master podspec repo is set up (will update if it exists).
-        report_command "pod setup"
+        sh "pod setup"
       end
 
       def verify_carthage
@@ -1056,7 +1056,7 @@ EOF
           exit(-1)
         end
 
-        report_command "brew install carthage"
+        sh "brew install carthage"
       end
 
       def verify_git
@@ -1077,7 +1077,7 @@ EOF
           exit(-1)
         end
 
-        report_command "xcode-select --install"
+        sh "xcode-select --install"
       end
     end
   end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -11,8 +11,6 @@ require "branch_io_cli/helper/methods"
 module BranchIOCLI
   module Helper
     module IOSHelper
-      include Methods
-
       APPLINKS = "applinks"
       ASSOCIATED_DOMAINS = "com.apple.developer.associated-domains"
       CODE_SIGN_ENTITLEMENTS = "CODE_SIGN_ENTITLEMENTS"

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -1,8 +1,8 @@
 module BranchIOCLI
   module Helper
     module Methods
-      def report_command(command)
-        STDOUT.report_command command
+      def sh(command, output = STDOUT)
+        output.report_command command
       end
     end
   end

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -1,8 +1,22 @@
 module BranchIOCLI
   module Helper
+    class CommandError < RuntimeError; end
+
     module Methods
+      # Execute a shell command with reporting.
+      # The command itself is logged, then output from
+      # both stdout and stderr, then a success or failure
+      # message. Raises CommandError on error.
+      #
+      # If output is STDOUT (the default), no redirection occurs. In all
+      # other cases, both stdout and stderr are redirected to output.
+      # In these cases, formatting (colors, highlights) may be lost.
+      #
+      # :command: [String] A shell command to execute
+      # :output: [IO] An optional IO object to receive stdout and stderr from the command
       def sh(command, output = STDOUT)
-        output.report_command command
+        status = output.report_command command
+        raise CommandError, %{Error executing "#{command}": #{status}.} unless status.success?
       end
     end
   end

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -21,3 +21,5 @@ module BranchIOCLI
     end
   end
 end
+
+include BranchIOCLI::Helper::Methods


### PR DESCRIPTION
This includes a number of improvements to shell command handling. Calls to `sh` now raise `BranchIOCLI::Helper::CommandError` when a command fails. This has the desirable effect of reporting the error to the user and halting execution by default.