### PR TITLE
Improve report inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ report with additional diagnostic information suitable for opening a support tic
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--scheme MyAppScheme|Name of a scheme to build|
-|--configuration Debug/Release/CustomConfig|Name of a build configuration|
+|--configuration Debug/Release/CustomConfig|Name of a build configuration (default: Release)|
+|--sdk iphonesimulator|Name of an SDK to use with xcodebuild (default: iphonesimulator)|
 |--[no-]clean|Clean before building (default: yes)|
 |--[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -163,6 +163,7 @@ EOF
         c.option "--scheme MyProjectScheme", String, "A scheme from the project or workspace to build"
         c.option "--target MyProjectTarget", String, "A target to build"
         c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Release)"
+        c.option "--sdk iphonesimulator", String, "Passed as -sdk to xcodebuild (default: iphonesimulator)"
         c.option "--podfile /path/to/Podfile", String, "Path to the Podfile for the project"
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
@@ -170,7 +171,12 @@ EOF
         c.option "--out branch-report.txt", String, "Report output path (default: ./branch-report.txt)"
 
         c.action do |args, options|
-          options.default clean: true, header_only: false, configuration: "Release"
+          options.default(
+            clean: true,
+            header_only: false,
+            configuration: "Release",
+            sdk: "iphonesimulator"
+          )
           Commands::ReportCommand.new(options).run!
         end
       end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -170,7 +170,7 @@ EOF
         c.option "--out branch-report.txt", String, "Report output path (default: ./branch-report.txt)"
 
         c.action do |args, options|
-          options.default clean: true, header_only: false
+          options.default clean: true, header_only: false, configuration: "Release"
           Commands::ReportCommand.new(options).run!
         end
       end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -18,7 +18,7 @@ module BranchIOCLI
 
         File.open config_helper.report_path, "w" do |report|
           report.write "Branch.io Xcode build report v #{VERSION} #{DateTime.now}\n\n"
-          # TODO: Write out command-line options or configuration from helper
+          report.write "#{report_configuration}\n"
           report.write "#{report_header}\n"
 
           # run xcodebuild -list
@@ -40,7 +40,7 @@ module BranchIOCLI
           report.report_command "#{base_cmd} -showBuildSettings"
 
           # Add more options for the rest of the commands
-          base_cmd = "#{base_cmd} -configuration #{config_helper.configuration} -sdk iphonesimulator"
+          base_cmd = "#{base_cmd} -configuration #{config_helper.configuration} -sdk #{config_helper.sdk}"
           base_cmd = "#{base_cmd} -target #{config_helper.target}" unless config_helper.workspace_path
 
           if config_helper.clean
@@ -139,6 +139,22 @@ module BranchIOCLI
         return nil unless matches
         version = matches[1]
         "#{version} [BNCConfig.m]"
+      end
+
+      def report_configuration
+        <<EOF
+Configuration:
+
+Xcode workspace: #{config_helper.workspace_path || '(none)'}
+Xcode project: #{config_helper.xcodeproj_path || '(none)'}
+Scheme: #{config_helper.scheme || '(none)'}
+Target: #{config_helper.target || '(none)'}
+Configuration: #{config_helper.configuration || '(none)'}
+SDK: #{config_helper.sdk}
+Podfile: #{config_helper.podfile_path || '(none)'}
+Cartfile: #{config_helper.cartfile_path || '(none)'}
+Clean: #{config_helper.clean.inspect}
+EOF
       end
 
       def report_header

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -41,6 +41,7 @@ module BranchIOCLI
         attr_reader :scheme
         attr_reader :configuration
         attr_reader :report_path
+        attr_reader :sdk
 
         def validate_setup_options(options)
           print_identification "setup"
@@ -100,6 +101,7 @@ module BranchIOCLI
           @target = options.target
           @configuration = options.configuration
           @report_path = options.out || "./report.txt"
+          @sdk = options.sdk
 
           validate_xcodeproj_and_workspace options
           validate_target options
@@ -168,7 +170,8 @@ EOF
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path || '(none)'}
 <%= color('Scheme:', BOLD) %> #{@scheme || '(none)'}
 <%= color('Target:', BOLD) %> #{@target || '(none)'}
-<%= color('Configuration:', BOLD) %> #{@configuration || '(none)'}
+<%= color('Configuration:', BOLD) %> #{@configuration}
+<%= color('SDK:', BOLD) %> #{@sdk}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
 <%= color('Clean:', BOLD) %> #{@clean.inspect}

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -102,6 +102,7 @@ module BranchIOCLI
           @report_path = options.out || "./report.txt"
 
           validate_xcodeproj_and_workspace options
+          validate_target options
           validate_scheme options
 
           # If neither --podfile nor --cartfile is present, arbitrarily look for a Podfile
@@ -337,11 +338,15 @@ EOF
 
         def validate_scheme(options)
           schemes = all_schemes
+          # TODO: Prompt if --scheme specified but not found.
           if options.scheme && schemes.include?(options.scheme)
             @scheme = options.scheme
           elsif schemes.count == 1
             @scheme = schemes.first
           elsif !schemes.empty?
+            # By default, take a scheme with the same name as the target name.
+            return if (@scheme = schemes.find { |s| s == @target.name })
+
             say "Please specify one of the following for the --scheme argument:"
             schemes.each do |scheme|
               say " #{scheme}"

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -339,7 +339,8 @@ module BranchIOCLI
           raise "Target #{target} not found" if target.nil?
         else
           # find the first application target
-          target = project.targets.find { |t| !t.extension_target_type? && !t.test_target_type? }
+          targets = project.targets.select { |t| !t.extension_target_type? && !t.test_target_type? }
+          target = targets.find { |t| t.name == File.basename(project.path).sub(/\.xcodeproj$/, "") } || targets.first
           raise "No application target found" if target.nil?
         end
         target

--- a/lib/branch_io_cli/version.rb
+++ b/lib/branch_io_cli/version.rb
@@ -1,3 +1,3 @@
 module BranchIOCLI
-  VERSION = "0.7.2"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Added a new option to the `report` command: `--sdk` is passed as `-sdk` to `xcodebuild`. Bumped the version to 0.8.0 as a result.

Improved inference of targets and schemes, especially in the `report` command.

Improved the `xcodebuild` command options used in the `report` command.

Added configuration to the report header.