### PR TITLE
Report versions of build tools

### DIFF
--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -202,7 +202,7 @@ EOF
         if version
           header = "#{header}\nBranch SDK v. #{version}\n"
         else
-          header = "Branch SDK not found.\n"
+          header = "#{header}\nBranch SDK not found.\n"
         end
 
         header

--- a/lib/branch_io_cli/core_ext/io.rb
+++ b/lib/branch_io_cli/core_ext/io.rb
@@ -34,7 +34,7 @@ end
 # :command: [String] a shell command to execute and report
 def STDOUT.report_command(command)
   # TODO: Improve this implementation?
-  say "<%= color(%q{$ #{command}}, BOLD) %>\n\n"
+  say "<%= color(%q{$ #{command}}, [MAGENTA, BOLD]) %>\n\n"
   # May also write to stderr
   # Could try system "#{command} 2>&1", but that might depend on the shell.
   system command

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -130,7 +130,7 @@ EOF
 
         def print_setup_configuration
           say <<EOF
-<%= color('Configuration:', BOLD) %>
+<%= color('Configuration:', [CYAN, BOLD, UNDERLINE]) %>
 
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
 <%= color('Target:', BOLD) %> #{@target.name}
@@ -154,7 +154,7 @@ EOF
 
         def print_validation_configuration
           say <<EOF
-<%= color('Configuration:', BOLD) %>
+<%= color('Configuration:', [CYAN, BOLD, UNDERLINE]) %>
 
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path}
 <%= color('Target:', BOLD) %> #{@target.name}
@@ -164,7 +164,7 @@ EOF
 
         def print_report_configuration
           say <<EOF
-<%= color('Configuration:', BOLD) %>
+<%= color('Configuration:', [CYAN, BOLD, UNDERLINE]) %>
 
 <%= color('Xcode workspace:', BOLD) %> #{@workspace_path || '(none)'}
 <%= color('Xcode project:', BOLD) %> #{@xcodeproj_path || '(none)'}


### PR DESCRIPTION
The version of CocoaPods is already reported if a Podfile.lock is found. In addition, the version of the `pod` command will be reported (`pod --version`).

The version of Carthage is reported via `carthage version`.

Added some color and other styling to the output.