### PR TITLE
Update default --out value

### DIFF
--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -168,14 +168,15 @@ EOF
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
         c.option "--[no-]header-only", "Write a report header to standard output and exit"
-        c.option "--out branch-report.txt", String, "Report output path (default: ./branch-report.txt)"
+        c.option "--out ./report.txt", String, "Report output path (default: ./report.txt)"
 
         c.action do |args, options|
           options.default(
             clean: true,
             header_only: false,
             configuration: "Release",
-            sdk: "iphonesimulator"
+            sdk: "iphonesimulator",
+            out: "./report.txt"
           )
           Commands::ReportCommand.new(options).run!
         end

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -100,7 +100,7 @@ module BranchIOCLI
           @scheme = options.scheme
           @target = options.target
           @configuration = options.configuration
-          @report_path = options.out || "./report.txt"
+          @report_path = options.out
           @sdk = options.sdk
 
           validate_xcodeproj_and_workspace options


### PR DESCRIPTION
The README was correct. The output of `report -h` was not. This also moves the default value to `cli.rb` where it's easier to compare with the text.