### PR TITLE
New report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ report with additional diagnostic information suitable for opening a support tic
 |--sdk iphonesimulator|Name of an SDK to use with xcodebuild (default: iphonesimulator)|
 |--[no-]clean|Clean before building (default: yes)|
 |--[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|
+|--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|
 |--out ./report.txt|Path to use for the generated report (default: ./report.txt)|

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -18,7 +18,8 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
-    report_opts="$global_opts --xcodeproj --workspace --header-only --no-clean --scheme --target --configuration --out"
+    report_opts="$global_opts --xcodeproj --workspace --header-only --no-clean --scheme --target --configuration --sdk --out"
+    report_opts="$global_opts --podfile --cartfile --no-pod-repo-update"
 
     if [[ ${cur} == -* ]] ; then
       case "${cmd}" in

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -168,6 +168,7 @@ EOF
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
         c.option "--[no-]header-only", "Write a report header to standard output and exit"
+        c.option "--[no-]pod-repo-update", "Update the local podspec repo before installing (default: yes)"
         c.option "--out ./report.txt", String, "Report output path (default: ./report.txt)"
 
         c.action do |args, options|
@@ -176,7 +177,8 @@ EOF
             header_only: false,
             configuration: "Release",
             sdk: "iphonesimulator",
-            out: "./report.txt"
+            out: "./report.txt",
+            pod_repo_update: true
           )
           Commands::ReportCommand.new(options).run!
         end

--- a/lib/branch_io_cli/commands/report_command.rb
+++ b/lib/branch_io_cli/commands/report_command.rb
@@ -28,7 +28,19 @@ module BranchIOCLI
 
           helper.verify_cocoapods
 
-          sh "pod install"
+          install_command = "pod install"
+
+          if config_helper.pod_repo_update
+            install_command += " --repo-update"
+          else
+            say <<EOF
+You have disabled "pod repo update". This can cause "pod install" to fail in
+some cases. If that happens, please rerun without --no-pod-repo-update or run
+"pod install --repo-update" manually.
+EOF
+          end
+
+          sh install_command
         end
 
         File.open config_helper.report_path, "w" do |report|
@@ -168,6 +180,7 @@ Configuration: #{config_helper.configuration || '(none)'}
 SDK: #{config_helper.sdk}
 Podfile: #{config_helper.podfile_path || '(none)'}
 Cartfile: #{config_helper.cartfile_path || '(none)'}
+Pod repo update: #{config_helper.pod_repo_update.inspect}
 Clean: #{config_helper.clean.inspect}
 EOF
       end

--- a/lib/branch_io_cli/helper/configuration_helper.rb
+++ b/lib/branch_io_cli/helper/configuration_helper.rb
@@ -102,6 +102,7 @@ module BranchIOCLI
           @configuration = options.configuration
           @report_path = options.out
           @sdk = options.sdk
+          @pod_repo_update = options.pod_repo_update
 
           validate_xcodeproj_and_workspace options
           validate_target options
@@ -174,6 +175,7 @@ EOF
 <%= color('SDK:', BOLD) %> #{@sdk}
 <%= color('Podfile:', BOLD) %> #{@podfile_path || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{@cartfile_path || '(none)'}
+<%= color('Pod repo update:', BOLD) %> #{@pod_repo_update.inspect}
 <%= color('Clean:', BOLD) %> #{@clean.inspect}
 <%= color('Report path:', BOLD) %> #{@report_path}
 EOF

--- a/lib/branch_io_cli/version.rb
+++ b/lib/branch_io_cli/version.rb
@@ -1,3 +1,3 @@
 module BranchIOCLI
-  VERSION = "0.8.1"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
Added `--[no-]pod-repo-update` to `report` command, like `setup`.

When repo update is not disabled this way, and `pod install` is required, `--repo-update` is added to the command. This is the default. If it's disabled, a warning is generated. In some cases, the Podfile.lock can require a version of a pod that's not present in the local master repo, and `pod install` can fail without a repo update. In that case, the user must run `pod repo update`, `pod install --repo-update` or `pod update` or rerun `branch_io report` without `--no-pod-repo-update`.