### PR TITLE
Command improvements

### DIFF
--- a/lib/branch_io_cli/commands/setup_command.rb
+++ b/lib/branch_io_cli/commands/setup_command.rb
@@ -101,6 +101,7 @@ module BranchIOCLI
           sh "git commit -aqm'#{message}'"
         else
           say "Please stash or commit your changes before continuing."
+          exit(-1)
         end
       end
     end


### PR DESCRIPTION
Check git repo status (if using git) before running the `setup` command. Offer to stash or commit the changes or let the user quit and do it manually. This makes it easier to recover in case of any mistake on the part of the CLI or the user. It also makes it easier to see what the CLI changed. Any commit generated with the `--commit` option will be clean, purely produced by the CLI.

Also some small improvements to `pod_install_required?` in the `report` command.