### PR TITLE
Patch helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem "pattern_patch", path: "../../jdee/pattern_patch"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem "pattern_patch", path: "../../jdee/pattern_patch"
 gemspec

--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'cocoapods-core'
   spec.add_dependency 'commander'
-  spec.add_dependency 'pattern_patch'
+  spec.add_dependency 'pattern_patch', '>= 0.2.0'
   spec.add_dependency 'plist'
   spec.add_dependency 'rubyzip'
   spec.add_dependency 'xcodeproj'

--- a/lib/assets/patches/cartfile.yml
+++ b/lib/assets/patches/cartfile.yml
@@ -1,0 +1,3 @@
+regexp: '\z'
+text: "github \"BranchMetrics/ios-branch-deep-linking\"\n"
+mode: append

--- a/lib/assets/patches/objc_import.yml
+++ b/lib/assets/patches/objc_import.yml
@@ -1,0 +1,3 @@
+regexp: '^\s+@import|^\s+#import.*$'
+text: "\n#import <Branch/Branch.h>"
+mode: prepend

--- a/lib/assets/patches/swift_import.yml
+++ b/lib/assets/patches/swift_import.yml
@@ -1,0 +1,3 @@
+regexp: '^\s*import .*$'
+text: "\nimport Branch"
+mode: prepend

--- a/lib/branch_io_cli/command/command.rb
+++ b/lib/branch_io_cli/command/command.rb
@@ -15,6 +15,10 @@ module BranchIOCLI
       def helper
         Helper::BranchHelper
       end
+
+      def patch_helper
+        Helper::PatchHelper
+      end
     end
   end
 end

--- a/lib/branch_io_cli/command/command.rb
+++ b/lib/branch_io_cli/command/command.rb
@@ -15,10 +15,6 @@ module BranchIOCLI
       def helper
         Helper::BranchHelper
       end
-
-      def config_helper
-        Helper::ConfigurationHelper
-      end
     end
   end
 end

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -59,7 +59,7 @@ module BranchIOCLI
 
         xcodeproj.save
 
-        helper.patch_source xcodeproj if options.patch_source
+        patch_helper.patch_source xcodeproj if options.patch_source
 
         return unless options.commit
 

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -191,13 +191,13 @@ EOF
           menu.prompt = "What would you like to do?"
         end
 
-        self.sdk_integration_mode = SDK_OPTIONS[selected]
+        @sdk_integration_mode = SDK_OPTIONS[selected]
 
         case sdk_integration_mode
         when :cocoapods
-          self.podfile_path = File.expand_path "../Podfile", xcodeproj_path
+          @podfile_path = File.expand_path "../Podfile", xcodeproj_path
         when :carthage
-          self.cartfile_path = File.expand_path "../Cartfile", xcodeproj_path
+          @cartfile_path = File.expand_path "../Cartfile", xcodeproj_path
           @carthage_command = options.carthage_command
         end
       end

--- a/lib/branch_io_cli/helper.rb
+++ b/lib/branch_io_cli/helper.rb
@@ -1,1 +1,2 @@
 require "branch_io_cli/helper/branch_helper"
+require "branch_io_cli/helper/patch_helper"

--- a/lib/branch_io_cli/helper/branch_helper.rb
+++ b/lib/branch_io_cli/helper/branch_helper.rb
@@ -19,22 +19,6 @@ module BranchIOCLI
           @changes << change.to_s
         end
 
-        # Shim around PatternPatch for now
-        def apply_patch(options)
-          modified = File.open(options[:files]) do |file|
-            PatternPatch::Utilities.apply_patch file.read,
-                                                options[:regexp],
-                                                options[:text],
-                                                options[:global],
-                                                options[:mode],
-                                                options[:offset] || 0
-          end
-
-          File.open(options[:files], "w") do |file|
-            file.write modified
-          end
-        end
-
         def fetch(url)
           response = Net::HTTP.get_response URI(url)
 

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -2,6 +2,7 @@ require "json"
 require "net/http"
 require "openssl"
 require "pathname"
+require "pattern_patch"
 require "plist"
 require "tmpdir"
 require "zip"
@@ -386,409 +387,6 @@ module BranchIOCLI
         setting_value
       end
 
-      def patch_app_delegate_swift(project)
-        app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
-        return false if app_delegate_swift.nil?
-
-        app_delegate_swift_path = app_delegate_swift.real_path.to_s
-
-        app_delegate = File.read app_delegate_swift_path
-        return false if app_delegate =~ /import\s+Branch/
-
-        say "Patching #{app_delegate_swift_path}"
-
-        apply_patch(
-          files: app_delegate_swift_path,
-          regexp: /^\s*import .*$/,
-          text: "\nimport Branch",
-          mode: :prepend
-        )
-
-        patch_did_finish_launching_method_swift app_delegate_swift_path
-        patch_continue_user_activity_method_swift app_delegate_swift_path
-        patch_open_url_method_swift app_delegate_swift_path
-
-        add_change app_delegate_swift_path
-        true
-      end
-
-      def patch_app_delegate_objc(project)
-        app_delegate_objc = project.files.find { |f| f.path =~ /AppDelegate.m$/ }
-        return false if app_delegate_objc.nil?
-
-        app_delegate_objc_path = app_delegate_objc.real_path.to_s
-
-        app_delegate = File.read app_delegate_objc_path
-        return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch;}
-
-        say "Patching #{app_delegate_objc_path}"
-
-        apply_patch(
-          files: app_delegate_objc_path,
-          regexp: /^\s+@import|^\s+#import.*$/,
-          text: "\n#import <Branch/Branch.h>",
-          mode: :prepend
-        )
-
-        patch_did_finish_launching_method_objc app_delegate_objc_path
-        patch_continue_user_activity_method_objc app_delegate_objc_path
-        patch_open_url_method_objc app_delegate_objc_path
-
-        add_change app_delegate_objc_path
-        true
-      end
-
-      def patch_did_finish_launching_method_swift(app_delegate_swift_path)
-        app_delegate_swift = File.read app_delegate_swift_path
-
-        if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
-          # method already present
-          init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
-        #if DEBUG
-            Branch.setUseTestBranchKey(true)
-        #endif
-
-EOF
-
-          init_session_text += <<-EOF
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
-        EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m,
-            text: init_session_text,
-            mode: :append
-          )
-        else
-          # method not present. add entire method
-
-          method_text = <<EOF
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-EOF
-
-          if config.keys.count > 1 && !has_multiple_info_plists?
-            method_text += <<EOF
-        #if DEBUG
-          Branch.setUseTestBranchKey(true)
-        #endif
-
-EOF
-          end
-
-          method_text += <<-EOF
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
-        return true
-    }
-        EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /var\s+window\s?:\s?UIWindow\?.*?\n/m,
-            text: method_text,
-            mode: :append
-          )
-        end
-      end
-
-      def patch_did_finish_launching_method_objc(app_delegate_objc_path)
-        app_delegate_objc = File.read app_delegate_objc_path
-
-        if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
-          # method exists. patch it.
-          init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
-#ifdef DEBUG
-    [Branch setUseTestBranchKey:YES];
-#endif // DEBUG
-
-EOF
-
-          init_session_text += <<-EOF
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
-          EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m,
-            text: init_session_text,
-            mode: :append
-          )
-        else
-          # method does not exist. add it.
-          method_text = <<EOF
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-EOF
-
-          if config.keys.count > 1 && !has_multiple_info_plists?
-            method_text += <<EOF
-#ifdef DEBUG
-    [Branch setUseTestBranchKey:YES];
-#endif // DEBUG
-
-EOF
-          end
-
-          method_text += <<-EOF
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
-    return YES;
-}
-          EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /^@implementation.*?\n/m,
-            text: method_text,
-            mode: :append
-          )
-        end
-      end
-
-      def patch_open_url_method_swift(app_delegate_swift_path)
-        app_delegate_swift = File.read app_delegate_swift_path
-        if app_delegate_swift =~ /application.*open\s+url.*options/
-          # Has application:openURL:options:
-          open_url_text = <<-EOF
-        // TODO: Adjust your method as you see fit.
-        if Branch.getInstance().application(app, open: url, options: options) {
-            return true
-        }
-
-          EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /application.*open\s+url.*options:.*?\{.*?\n/m,
-            text: open_url_text,
-            mode: :append
-          )
-        elsif app_delegate_swift =~ /application.*open\s+url.*sourceApplication/
-          # Has application:openURL:sourceApplication:annotation:
-          # TODO: This method is deprecated.
-          open_url_text = <<-EOF
-        // TODO: Adjust your method as you see fit.
-        if Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation) {
-            return true
-        }
-
-          EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /application.*open\s+url.*sourceApplication:.*?\{.*?\n/m,
-            text: open_url_text,
-            mode: :append
-          )
-        else
-          # Has neither
-          open_url_text = <<EOF
-
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-        return Branch.getInstance().application(app, open: url, options: options)
-    }
-EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /\n\s*\}[^{}]*\Z/m,
-            text: open_url_text,
-            mode: :prepend
-          )
-        end
-      end
-
-      def patch_continue_user_activity_method_swift(app_delegate_swift_path)
-        app_delegate = File.read app_delegate_swift_path
-        if app_delegate =~ /application:.*continue userActivity:.*restorationHandler:/
-          # Add something to the top of the method
-          continue_user_activity_text = <<-EOF
-        // TODO: Adjust your method as you see fit.
-        if Branch.getInstance.continue(userActivity) {
-            return true
-        }
-
-          EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /application:.*continue userActivity:.*restorationHandler:.*?\{.*?\n/m,
-            text: continue_user_activity_text,
-            mode: :append
-          )
-        else
-          # Add the application:continueUserActivity:restorationHandler method if it does not exist
-          continue_user_activity_text = <<-EOF
-
-
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
-        return Branch.getInstance().continue(userActivity)
-    }
-          EOF
-
-          apply_patch(
-            files: app_delegate_swift_path,
-            regexp: /\n\s*\}[^{}]*\Z/m,
-            text: continue_user_activity_text,
-            mode: :prepend
-          )
-        end
-      end
-
-      def patch_open_url_method_objc(app_delegate_objc_path)
-        app_delegate_objc = File.read app_delegate_objc_path
-        if app_delegate_objc =~ /application:.*openURL:.*options/
-          # Has application:openURL:options:
-          open_url_text = <<-EOF
-    // TODO: Adjust your method as you see fit.
-    if ([[Branch getInstance] application:app openURL:url options:options]) {
-        return YES;
-    }
-
-EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /application:.*openURL:.*options:.*?\{.*?\n/m,
-            text: open_url_text,
-            mode: :append
-          )
-        elsif app_delegate_objc =~ /application:.*openURL:.*sourceApplication/
-          # Has application:openURL:sourceApplication:annotation:
-          open_url_text = <<-EOF
-    // TODO: Adjust your method as you see fit.
-    if ([[Branch getInstance] application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
-        return YES;
-    }
-
-EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /application:.*openURL:.*sourceApplication:.*?\{.*?\n/m,
-            text: open_url_text,
-            mode: :append
-          )
-        else
-          # Has neither
-          open_url_text = <<-EOF
-
-
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-{
-    return [[Branch getInstance] application:app openURL:url options:options];
-}
-          EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /\n\s*@end[^@]*\Z/m,
-            text: open_url_text,
-            mode: :prepend
-          )
-        end
-      end
-
-      def patch_continue_user_activity_method_objc(app_delegate_objc_path)
-        app_delegate = File.read app_delegate_objc_path
-        if app_delegate =~ /application:.*continueUserActivity:.*restorationHandler:/
-          continue_user_activity_text = <<-EOF
-    // TODO: Adjust your method as you see fit.
-    if ([[Branch getInstance] continueUserActivity:userActivity]) {
-        return YES;
-    }
-
-EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /application:.*continueUserActivity:.*restorationHandler:.*?\{.*?\n/m,
-            text: continue_user_activity_text,
-            mode: :append
-          )
-        else
-          # Add the application:continueUserActivity:restorationHandler method if it does not exist
-          continue_user_activity_text = <<-EOF
-
-
-- (BOOL)application:(UIApplication *)app continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler
-{
-    return [[Branch getInstance] continueUserActivity:userActivity];
-}
-          EOF
-
-          apply_patch(
-            files: app_delegate_objc_path,
-            regexp: /\n\s*@end[^@]*\Z/m,
-            text: continue_user_activity_text,
-            mode: :prepend
-          )
-        end
-      end
-
-      def patch_podfile(podfile_path)
-        podfile = File.read podfile_path
-
-        # Podfile already contains the Branch pod
-        # TODO: Allow for adding to multiple targets in the Podfile
-        return false if podfile =~ /pod\s+('Branch'|"Branch")/
-
-        say "Adding pod \"Branch\" to #{podfile_path}"
-
-        if podfile =~ /target\s+(["'])#{config.target.name}\1\s+do.*?\n/m
-          # if there is a target block for this target:
-          apply_patch(
-            files: podfile_path,
-            regexp: /\n(\s*)target\s+(["'])#{config.target.name}\2\s+do.*?\n/m,
-            text: "\\1  pod \"Branch\"\n",
-            mode: :append
-          )
-        else
-          # add to the abstract_target for this target
-          apply_patch(
-            files: podfile_path,
-            regexp: /^(\s*)target\s+["']#{config.target.name}/,
-            text: "\\1pod \"Branch\"\n",
-            mode: :prepend
-          )
-        end
-
-        true
-      end
-
-      def patch_cartfile(cartfile_path)
-        cartfile = File.read cartfile_path
-
-        # Cartfile already contains the Branch framework
-        return false if cartfile =~ /git.+Branch/
-
-        say "Adding \"Branch\" to #{cartfile_path}"
-
-        apply_patch(
-          files: cartfile_path,
-          regexp: /\z/,
-          text: "github \"BranchMetrics/ios-branch-deep-linking\"\n",
-          mode: :append
-        )
-
-        true
-      end
-
       def add_cocoapods(options)
         verify_cocoapods
 
@@ -798,13 +396,11 @@ EOF
         install_command += " --repo-update" if options.pod_repo_update
         Dir.chdir(File.dirname(podfile_path)) do
           sh "pod init"
-          apply_patch(
-            files: podfile_path,
+          PatternPatch::Patch.new(
             regexp: /^(\s*)# Pods for #{config.target.name}$/,
             mode: :append,
-            text: "\n\\1pod \"Branch\"",
-            global: false
-          )
+            text: "\n\\1pod \"Branch\""
+          ).apply podfile_path
           sh install_command
         end
 
@@ -939,7 +535,7 @@ EOF
         return false if podfile_path.nil?
 
         # 1. Patch Podfile. Return if no change (Branch pod already present).
-        return false unless patch_podfile podfile_path
+        return false unless PatchHelper.patch_podfile podfile_path
 
         # 2. pod install
         # command = "PATH='#{ENV['PATH']}' pod install"
@@ -973,7 +569,7 @@ EOF
         return false if cartfile_path.nil?
 
         # 1. Patch Cartfile. Return if no change (Branch already present).
-        return false unless patch_cartfile cartfile_path
+        return false unless PatchHelper.patch_cartfile cartfile_path
 
         # 2. carthage update
         Dir.chdir(File.dirname(cartfile_path)) do
@@ -1011,10 +607,6 @@ EOF
         sh "git add #{carthage_folder_path}" if options.commit
 
         true
-      end
-
-      def patch_source(xcodeproj)
-        patch_app_delegate_swift(xcodeproj) || patch_app_delegate_objc(xcodeproj)
       end
 
       def verify_cocoapods

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -5,7 +5,7 @@ module BranchIOCLI
     class PatchHelper
       class << self
         def load_patch(name)
-          path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches', name), __FILE__)
+          path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches', "#{name}.yml"), __FILE__)
           PatternPatch::Patch.from_yaml path
         end
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -224,7 +224,7 @@ EOF
 EOF
 
             PatternPatch::Patch.new(
-              regexp: /\n\s*\}.*?\Z/m,
+              regexp: /\n\s*\}[^{}]*\Z/m,
               text: open_url_text,
               mode: :prepend
             ).apply app_delegate_swift_path

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -6,7 +6,7 @@ module BranchIOCLI
       class << self
         def load_patch(name)
           path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches'), __FILE__)
-          PatternPatch::Patch.load_yaml path
+          PatternPatch::Patch.from_yaml path
         end
 
         def patch_app_delegate_swift(project)

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -32,11 +32,7 @@ module BranchIOCLI
 
           say "Patching #{app_delegate_swift_path}"
 
-          PatternPatch::Patch.new(
-            regexp: /^\s*import .*$/,
-            text: "\nimport Branch",
-            mode: :prepend
-          ).apply app_delegate_swift_path
+          load_patch(:swift_import).apply app_delegate_swift_path
 
           patch_did_finish_launching_method_swift app_delegate_swift_path
           patch_continue_user_activity_method_swift app_delegate_swift_path
@@ -57,11 +53,7 @@ module BranchIOCLI
 
           say "Patching #{app_delegate_objc_path}"
 
-          PatternPatch::Patch.new(
-            regexp: /^\s+@import|^\s+#import.*$/,
-            text: "\n#import <Branch/Branch.h>",
-            mode: :prepend
-          ).apply app_delegate_objc_path
+          load_patch(:objc_import).apply app_delegate_objc_path
 
           patch_did_finish_launching_method_objc app_delegate_objc_path
           patch_continue_user_activity_method_objc app_delegate_objc_path
@@ -397,7 +389,7 @@ EOF
 
           say "Adding \"Branch\" to #{cartfile_path}"
 
-          load_patch('cartfile').apply cartfile_path
+          load_patch(:cartfile).apply cartfile_path
 
           true
         end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -69,9 +69,9 @@ module BranchIOCLI
           if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
             # method already present
             init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
-      #if DEBUG
-          Branch.setUseTestBranchKey(true)
-      #endif
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
 
 EOF
 
@@ -129,9 +129,9 @@ EOF
           if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
             # method exists. patch it.
             init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
-  #ifdef DEBUG
-      [Branch setUseTestBranchKey:YES];
-  #endif // DEBUG
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
 
 EOF
 
@@ -156,9 +156,9 @@ EOF
 
             if config.keys.count > 1 && !has_multiple_info_plists?
               method_text += <<EOF
-  #ifdef DEBUG
-      [Branch setUseTestBranchKey:YES];
-  #endif // DEBUG
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
 
 EOF
             end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -1,0 +1,398 @@
+require "pattern_patch"
+
+module BranchIOCLI
+  module Helper
+    class PatchHelper
+      class << self
+        def patch_app_delegate_swift(project)
+          app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
+          return false if app_delegate_swift.nil?
+
+          app_delegate_swift_path = app_delegate_swift.real_path.to_s
+
+          app_delegate = File.read app_delegate_swift_path
+          return false if app_delegate =~ /import\s+Branch/
+
+          say "Patching #{app_delegate_swift_path}"
+
+          PatternPatch::Patch.new(
+            regexp: /^\s*import .*$/,
+            text: "\nimport Branch",
+            mode: :prepend
+          ).apply app_delegate_swift_path
+
+          patch_did_finish_launching_method_swift app_delegate_swift_path
+          patch_continue_user_activity_method_swift app_delegate_swift_path
+          patch_open_url_method_swift app_delegate_swift_path
+
+          add_change app_delegate_swift_path
+          true
+        end
+
+        def patch_app_delegate_objc(project)
+          app_delegate_objc = project.files.find { |f| f.path =~ /AppDelegate.m$/ }
+          return false if app_delegate_objc.nil?
+
+          app_delegate_objc_path = app_delegate_objc.real_path.to_s
+
+          app_delegate = File.read app_delegate_objc_path
+          return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch;}
+
+          say "Patching #{app_delegate_objc_path}"
+
+          PatternPatch::Patch.new(
+            regexp: /^\s+@import|^\s+#import.*$/,
+            text: "\n#import <Branch/Branch.h>",
+            mode: :prepend
+          ).apply app_delegate_objc_path
+
+          patch_did_finish_launching_method_objc app_delegate_objc_path
+          patch_continue_user_activity_method_objc app_delegate_objc_path
+          patch_open_url_method_objc app_delegate_objc_path
+
+          add_change app_delegate_objc_path
+          true
+        end
+
+        def patch_did_finish_launching_method_swift(app_delegate_swift_path)
+          app_delegate_swift = File.read app_delegate_swift_path
+
+          if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
+            # method already present
+            init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
+      #if DEBUG
+          Branch.setUseTestBranchKey(true)
+      #endif
+
+EOF
+
+            init_session_text += <<-EOF
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m,
+              text: init_session_text,
+              mode: :append
+            ).apply app_delegate_swift_path
+          else
+            # method not present. add entire method
+
+            method_text = <<EOF
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+EOF
+
+            if config.keys.count > 1 && !has_multiple_info_plists?
+              method_text += <<EOF
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+EOF
+            end
+
+            method_text += <<-EOF
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+        return true
+    }
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /var\s+window\s?:\s?UIWindow\?.*?\n/m,
+              text: method_text,
+              mode: :append
+            ).apply app_delegate_swift_path
+          end
+        end
+
+        def patch_did_finish_launching_method_objc(app_delegate_objc_path)
+          app_delegate_objc = File.read app_delegate_objc_path
+
+          if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
+            # method exists. patch it.
+            init_session_text = config.keys.count <= 1 || has_multiple_info_plists? ? "" : <<EOF
+  #ifdef DEBUG
+      [Branch setUseTestBranchKey:YES];
+  #endif // DEBUG
+
+EOF
+
+            init_session_text += <<-EOF
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m,
+              text: init_session_text,
+              mode: :append
+            ).apply app_delegate_objc_path
+          else
+            # method does not exist. add it.
+            method_text = <<EOF
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+EOF
+
+            if config.keys.count > 1 && !has_multiple_info_plists?
+              method_text += <<EOF
+  #ifdef DEBUG
+      [Branch setUseTestBranchKey:YES];
+  #endif // DEBUG
+
+EOF
+            end
+
+            method_text += <<-EOF
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+    return YES;
+}
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /^@implementation.*?\n/m,
+              text: method_text,
+              mode: :append
+            ).apply app_delegate_objc_path
+          end
+        end
+
+        def patch_open_url_method_swift(app_delegate_swift_path)
+          app_delegate_swift = File.read app_delegate_swift_path
+          if app_delegate_swift =~ /application.*open\s+url.*options/
+            # Has application:openURL:options:
+            open_url_text = <<-EOF
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance().application(app, open: url, options: options) {
+            return true
+        }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application.*open\s+url.*options:.*?\{.*?\n/m,
+              text: open_url_text,
+              mode: :append
+            ).apply app_delegate_swift_path
+          elsif app_delegate_swift =~ /application.*open\s+url.*sourceApplication/
+            # Has application:openURL:sourceApplication:annotation:
+            # TODO: This method is deprecated.
+            open_url_text = <<-EOF
+              // TODO: Adjust your method as you see fit.
+              if Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation) {
+                  return true
+              }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application.*open\s+url.*sourceApplication:.*?\{.*?\n/m,
+              text: open_url_text,
+              mode: :append
+            ).apply app_delegate_swift_path
+          else
+            # Has neither
+            open_url_text = <<EOF
+
+
+        func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+            return Branch.getInstance().application(app, open: url, options: options)
+        }
+EOF
+
+            PatternPatch::Patch.new(
+              regexp: /\n\s*\}[^{}]*\Z/m,
+              text: open_url_text,
+              mode: :prepend
+            )
+          end
+        end
+
+        def patch_continue_user_activity_method_swift(app_delegate_swift_path)
+          app_delegate = File.read app_delegate_swift_path
+          if app_delegate =~ /application:.*continue userActivity:.*restorationHandler:/
+            # Add something to the top of the method
+            continue_user_activity_text = <<-EOF
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance.continue(userActivity) {
+            return true
+        }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application:.*continue userActivity:.*restorationHandler:.*?\{.*?\n/m,
+              text: continue_user_activity_text,
+              mode: :append
+            ).apply app_delegate_swift_path
+          else
+            # Add the application:continueUserActivity:restorationHandler method if it does not exist
+            continue_user_activity_text = <<-EOF
+
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        return Branch.getInstance().continue(userActivity)
+    }
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /\n\s*\}[^{}]*\Z/m,
+              text: continue_user_activity_text,
+              mode: :prepend
+            ).apply app_delegate_swift_path
+          end
+        end
+
+        def patch_open_url_method_objc(app_delegate_objc_path)
+          app_delegate_objc = File.read app_delegate_objc_path
+          if app_delegate_objc =~ /application:.*openURL:.*options/
+            # Has application:openURL:options:
+            open_url_text = <<-EOF
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] application:app openURL:url options:options]) {
+        return YES;
+    }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application:.*openURL:.*options:.*?\{.*?\n/m,
+              text: open_url_text,
+              mode: :append
+            ).apply app_delegate_objc_path
+          elsif app_delegate_objc =~ /application:.*openURL:.*sourceApplication/
+            # Has application:openURL:sourceApplication:annotation:
+            open_url_text = <<-EOF
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
+        return YES;
+    }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application:.*openURL:.*sourceApplication:.*?\{.*?\n/m,
+              text: open_url_text,
+              mode: :append
+            ).apply app_delegate_objc_path
+          else
+            # Has neither
+            open_url_text = <<-EOF
+
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    return [[Branch getInstance] application:app openURL:url options:options];
+}
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /\n\s*@end[^@]*\Z/m,
+              text: open_url_text,
+              mode: :prepend
+            ).apply app_delegate_objc_path
+          end
+        end
+
+        def patch_continue_user_activity_method_objc(app_delegate_objc_path)
+          app_delegate = File.read app_delegate_objc_path
+          if app_delegate =~ /application:.*continueUserActivity:.*restorationHandler:/
+            continue_user_activity_text = <<-EOF
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] continueUserActivity:userActivity]) {
+        return YES;
+    }
+
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /application:.*continueUserActivity:.*restorationHandler:.*?\{.*?\n/m,
+              text: continue_user_activity_text,
+              mode: :append
+            ).apply app_delegate_objc_path
+          else
+            # Add the application:continueUserActivity:restorationHandler method if it does not exist
+            continue_user_activity_text = <<-EOF
+
+
+- (BOOL)application:(UIApplication *)app continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler
+{
+    return [[Branch getInstance] continueUserActivity:userActivity];
+}
+            EOF
+
+            PatternPatch::Patch.new(
+              regexp: /\n\s*@end[^@]*\Z/m,
+              text: continue_user_activity_text,
+              mode: :prepend
+            ).apply app_delegate_objc_path
+          end
+        end
+
+        def patch_podfile(podfile_path)
+          podfile = File.read podfile_path
+
+          # Podfile already contains the Branch pod
+          # TODO: Allow for adding to multiple targets in the Podfile
+          return false if podfile =~ /pod\s+('Branch'|"Branch")/
+
+          say "Adding pod \"Branch\" to #{podfile_path}"
+
+          if podfile =~ /target\s+(["'])#{config.target.name}\1\s+do.*?\n/m
+            # if there is a target block for this target:
+            patch = PatternPatch::Patch.new(
+              regexp: /\n(\s*)target\s+(["'])#{config.target.name}\2\s+do.*?\n/m,
+              text: "\\1  pod \"Branch\"\n",
+              mode: :append
+            )
+          else
+            # add to the abstract_target for this target
+            patch = PatternPatch::Patch.new(
+              regexp: /^(\s*)target\s+["']#{config.target.name}/,
+              text: "\\1pod \"Branch\"\n",
+              mode: :prepend
+            )
+          end
+          patch.apply podfile_path
+
+          true
+        end
+
+        def patch_cartfile(cartfile_path)
+          cartfile = File.read cartfile_path
+
+          # Cartfile already contains the Branch framework
+          return false if cartfile =~ /git.+Branch/
+
+          say "Adding \"Branch\" to #{cartfile_path}"
+
+          PatternPatch::Patch.new(
+            regexp: /\z/,
+            text: "github \"BranchMetrics/ios-branch-deep-linking\"\n",
+            mode: :append
+          ).apply cartfile_path
+
+          true
+        end
+
+        def patch_source(xcodeproj)
+          patch_app_delegate_swift(xcodeproj) || patch_app_delegate_objc(xcodeproj)
+        end
+      end
+    end
+  end
+end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -224,7 +224,7 @@ EOF
 EOF
 
             PatternPatch::Patch.new(
-              regexp: /\n\s*\}[^{}]*\Z/m,
+              regexp: /\n\s*\}.*?\Z/m,
               text: open_url_text,
               mode: :prepend
             )

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -5,7 +5,7 @@ module BranchIOCLI
     class PatchHelper
       class << self
         def load_patch(name)
-          path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches'), __FILE__)
+          path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches', name), __FILE__)
           PatternPatch::Patch.from_yaml path
         end
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -9,6 +9,10 @@ module BranchIOCLI
           PatternPatch::Patch.from_yaml path
         end
 
+        def config
+          Configuration::Configuration.current
+        end
+
         def patch_app_delegate_swift(project)
           app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
           return false if app_delegate_swift.nil?

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -227,7 +227,7 @@ EOF
               regexp: /\n\s*\}.*?\Z/m,
               text: open_url_text,
               mode: :prepend
-            )
+            ).apply app_delegate_swift_path
           end
         end
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -218,9 +218,9 @@ EOF
             open_url_text = <<EOF
 
 
-        func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-            return Branch.getInstance().application(app, open: url, options: options)
-        }
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        return Branch.getInstance().application(app, open: url, options: options)
+    }
 EOF
 
             PatternPatch::Patch.new(

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -13,6 +13,14 @@ module BranchIOCLI
           Configuration::Configuration.current
         end
 
+        def helper
+          BranchHelper
+        end
+
+        def add_change(change)
+          helper.add_change change
+        end
+
         def patch_app_delegate_swift(project)
           app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
           return false if app_delegate_swift.nil?

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -4,6 +4,11 @@ module BranchIOCLI
   module Helper
     class PatchHelper
       class << self
+        def load_patch(name)
+          path = File.expand_path(File.join('..', '..', '..', 'assets', 'patches'), __FILE__)
+          PatternPatch::Patch.load_yaml path
+        end
+
         def patch_app_delegate_swift(project)
           app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
           return false if app_delegate_swift.nil?
@@ -380,11 +385,7 @@ EOF
 
           say "Adding \"Branch\" to #{cartfile_path}"
 
-          PatternPatch::Patch.new(
-            regexp: /\z/,
-            text: "github \"BranchMetrics/ios-branch-deep-linking\"\n",
-            mode: :append
-          ).apply cartfile_path
+          load_patch('cartfile').apply cartfile_path
 
           true
         end


### PR DESCRIPTION
Updated to `pattern_patch` 0.2.0 to use the `Patch` class. Introduced a `PatchHelper` in this gem, including support for loading literal patches from YAML (lib/assets/patches). A number of patches build the `regexp` or `text` in code. A future release of `pattern_patch` could perhaps support Ruby interpolation using ERB or something similar. For now, some patches are YAML, and some are built in Ruby.