### PR TITLE
Use shellwords to escape commit message and any paths

### DIFF
--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -101,7 +101,7 @@ module BranchIOCLI
           sh "git stash -q"
         when /^Commit/
           message = ask "Please enter a commit message: "
-          sh "git commit -aqm'#{Shellwords.escape(message)}'"
+          sh "git commit -aqm #{Shellwords.escape(message)}"
         else
           say "Please stash or commit your changes before continuing."
           exit(-1)

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -1,4 +1,5 @@
 require "branch_io_cli/helper/methods"
+require "shellwords"
 
 module BranchIOCLI
   module Command
@@ -53,7 +54,7 @@ module BranchIOCLI
         helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present
 
         new_path = helper.add_universal_links_to_project @domains, false if is_app_target
-        sh "git add #{new_path}" if options.commit && new_path
+        sh "git add #{Shellwords.escape(new_path)}" if options.commit && new_path
 
         config_helper.target.add_system_frameworks options.frameworks unless options.frameworks.nil? || options.frameworks.empty?
 
@@ -100,7 +101,7 @@ module BranchIOCLI
           sh "git stash -q"
         when /^Commit/
           message = ask "Please enter a commit message: "
-          sh "git commit -aqm'#{message}'"
+          sh "git commit -aqm'#{Shellwords.escape(message)}'"
         else
           say "Please stash or commit your changes before continuing."
           exit(-1)

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -4,6 +4,7 @@ require "openssl"
 require "pathname"
 require "pattern_patch"
 require "plist"
+require "shellwords"
 require "tmpdir"
 require "zip"
 
@@ -404,6 +405,8 @@ module BranchIOCLI
           sh install_command
         end
 
+        return unless config.commit
+
         add_change podfile_path
         add_change "#{podfile_path}.lock"
 
@@ -413,7 +416,12 @@ module BranchIOCLI
         podfile_pathname = Pathname.new(podfile_path).relative_path_from Pathname.pwd
         add_change pods_folder_path
         add_change workspace_path
-        sh "git add #{podfile_pathname} #{podfile_pathname}.lock #{pods_folder_path} #{workspace_path}" if options.commit
+
+        cmd = "git add #{Shellwords.escape(podfile_pathname)} " \
+          "#{Shellwords.escape(podfile_pathname)}.lock " \
+          "#{Shellwords.escape(pods_folder_path)} " \
+          "#{Shellwords.escape(workspace_path)}"
+        sh cmd
       end
 
       def add_carthage(options)
@@ -453,13 +461,18 @@ EOF
 
         config.xcodeproj.save
 
+        return unless config.commit
+
         # For now, add Carthage folder to SCM
 
         # 6. Add the Carthage folder to the commit (in case :commit param specified)
         carthage_folder_path = Pathname.new(File.expand_path("../Carthage", cartfile_path)).relative_path_from(Pathname.pwd)
         cartfile_pathname = Pathname.new(cartfile_path).relative_path_from Pathname.pwd
         add_change carthage_folder_path
-        sh "git add #{cartfile_pathname} #{cartfile_pathname}.resolved #{carthage_folder_path}" if options.commit
+        cmd = "git add #{Shellwords.escape(cartfile_pathname)} " \
+          "#{Shellwords.escape(cartfile_pathname)}.resolved " \
+          "#{Shellwords.escape(carthage_folder_path)}"
+        sh cmd
       end
 
       def add_direct(options)
@@ -523,7 +536,7 @@ EOF
 
         add_change config.xcodeproj_path
         add_change framework_path
-        sh "git add #{framework_path}" if options.commit
+        sh "git add #{Shellwords.escape(framework_path)}" if options.commit
 
         say "Done. ✅"
       end
@@ -557,7 +570,7 @@ EOF
 
         # 5. If so, add the Pods folder to the commit (in case :commit param specified)
         add_change pods_folder_path
-        sh "git add #{pods_folder_path}" if options.commit
+        sh "git add #{Shellwords.escape(pods_folder_path)}" if options.commit
 
         true
       end
@@ -604,7 +617,7 @@ EOF
 
         # 7. If so, add the Carthage folder to the commit (in case :commit param specified)
         add_change carthage_folder_path
-        sh "git add #{carthage_folder_path}" if options.commit
+        sh "git add #{Shellwords.escape(carthage_folder_path)}" if options.commit
 
         true
       end


### PR DESCRIPTION
This handles path components with spaces or any other special characters.