### PR TITLE
More YAML patches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem "pattern_patch", path: "../../jdee/pattern_patch"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem "pattern_patch", path: "../../jdee/pattern_patch"
 gemspec

--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'cocoapods-core'
   spec.add_dependency 'commander'
-  spec.add_dependency 'pattern_patch', '>= 0.2.0'
+  spec.add_dependency 'pattern_patch', '>= 0.3.0'
   spec.add_dependency 'plist'
   spec.add_dependency 'rubyzip'
   spec.add_dependency 'xcodeproj'

--- a/lib/assets/patches/ContinueUserActivity.m
+++ b/lib/assets/patches/ContinueUserActivity.m
@@ -1,0 +1,4 @@
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] continueUserActivity:userActivity]) {
+        return YES;
+    }

--- a/lib/assets/patches/ContinueUserActivity.swift
+++ b/lib/assets/patches/ContinueUserActivity.swift
@@ -1,0 +1,4 @@
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance.continue(userActivity) {
+            return true
+        }

--- a/lib/assets/patches/ContinueUserActivityNew.m
+++ b/lib/assets/patches/ContinueUserActivityNew.m
@@ -1,4 +1,5 @@
 
+
 - (BOOL)application:(UIApplication *)app continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler
 {
     return [[Branch getInstance] continueUserActivity:userActivity];

--- a/lib/assets/patches/ContinueUserActivityNew.m
+++ b/lib/assets/patches/ContinueUserActivityNew.m
@@ -1,0 +1,5 @@
+
+- (BOOL)application:(UIApplication *)app continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler
+{
+    return [[Branch getInstance] continueUserActivity:userActivity];
+}

--- a/lib/assets/patches/ContinueUserActivityNew.swift
+++ b/lib/assets/patches/ContinueUserActivityNew.swift
@@ -1,4 +1,5 @@
 
+
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
         return Branch.getInstance().continue(userActivity)
     }

--- a/lib/assets/patches/ContinueUserActivityNew.swift
+++ b/lib/assets/patches/ContinueUserActivityNew.swift
@@ -1,0 +1,4 @@
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        return Branch.getInstance().continue(userActivity)
+    }

--- a/lib/assets/patches/DidFinishLaunching.m
+++ b/lib/assets/patches/DidFinishLaunching.m
@@ -1,0 +1,4 @@
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];

--- a/lib/assets/patches/DidFinishLaunching.swift
+++ b/lib/assets/patches/DidFinishLaunching.swift
@@ -1,0 +1,5 @@
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }

--- a/lib/assets/patches/DidFinishLaunchingNew.m
+++ b/lib/assets/patches/DidFinishLaunchingNew.m
@@ -1,0 +1,8 @@
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+    return YES;
+}

--- a/lib/assets/patches/DidFinishLaunchingNew.m
+++ b/lib/assets/patches/DidFinishLaunchingNew.m
@@ -1,4 +1,5 @@
 
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
         andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){

--- a/lib/assets/patches/DidFinishLaunchingNew.swift
+++ b/lib/assets/patches/DidFinishLaunchingNew.swift
@@ -1,9 +1,5 @@
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        #if DEBUG
-            Branch.setUseTestBranchKey(true)
-        #endif
-
         Branch.getInstance().initSession(launchOptions: launchOptions) {
             universalObject, linkProperties, error in
 

--- a/lib/assets/patches/DidFinishLaunchingNew.swift
+++ b/lib/assets/patches/DidFinishLaunchingNew.swift
@@ -1,0 +1,12 @@
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+        return true
+    }

--- a/lib/assets/patches/DidFinishLaunchingNew.swift
+++ b/lib/assets/patches/DidFinishLaunchingNew.swift
@@ -1,3 +1,4 @@
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         #if DEBUG
             Branch.setUseTestBranchKey(true)

--- a/lib/assets/patches/DidFinishLaunchingNewTest.m
+++ b/lib/assets/patches/DidFinishLaunchingNewTest.m
@@ -1,4 +1,5 @@
 
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 #ifdef DEBUG
     [Branch setUseTestBranchKey:YES];

--- a/lib/assets/patches/DidFinishLaunchingNewTest.m
+++ b/lib/assets/patches/DidFinishLaunchingNewTest.m
@@ -1,0 +1,12 @@
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
+
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+    return YES;
+}

--- a/lib/assets/patches/DidFinishLaunchingNewTest.swift
+++ b/lib/assets/patches/DidFinishLaunchingNewTest.swift
@@ -1,0 +1,12 @@
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+        return true
+    }

--- a/lib/assets/patches/DidFinishLaunchingNewTest.swift
+++ b/lib/assets/patches/DidFinishLaunchingNewTest.swift
@@ -1,3 +1,4 @@
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         #if DEBUG
             Branch.setUseTestBranchKey(true)

--- a/lib/assets/patches/DidFinishLaunchingTest.m
+++ b/lib/assets/patches/DidFinishLaunchingTest.m
@@ -1,0 +1,8 @@
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
+
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];

--- a/lib/assets/patches/DidFinishLaunchingTest.swift
+++ b/lib/assets/patches/DidFinishLaunchingTest.swift
@@ -1,0 +1,9 @@
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }

--- a/lib/assets/patches/OpenUrl.m
+++ b/lib/assets/patches/OpenUrl.m
@@ -1,0 +1,4 @@
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] application:app openURL:url options:options]) {
+        return YES;
+    }

--- a/lib/assets/patches/OpenUrl.swift
+++ b/lib/assets/patches/OpenUrl.swift
@@ -1,0 +1,4 @@
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance().application(app, open: url, options: options) {
+            return true
+        }

--- a/lib/assets/patches/OpenUrlNew.m
+++ b/lib/assets/patches/OpenUrlNew.m
@@ -1,4 +1,5 @@
 
+
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     return [[Branch getInstance] application:app openURL:url options:options];

--- a/lib/assets/patches/OpenUrlNew.m
+++ b/lib/assets/patches/OpenUrlNew.m
@@ -1,0 +1,5 @@
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    return [[Branch getInstance] application:app openURL:url options:options];
+}

--- a/lib/assets/patches/OpenUrlNew.swift
+++ b/lib/assets/patches/OpenUrlNew.swift
@@ -1,0 +1,4 @@
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        return Branch.getInstance().application(app, open: url, options: options)
+    }

--- a/lib/assets/patches/OpenUrlNew.swift
+++ b/lib/assets/patches/OpenUrlNew.swift
@@ -1,4 +1,5 @@
 
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         return Branch.getInstance().application(app, open: url, options: options)
     }

--- a/lib/assets/patches/OpenUrlSourceApplication.m
+++ b/lib/assets/patches/OpenUrlSourceApplication.m
@@ -1,0 +1,4 @@
+    // TODO: Adjust your method as you see fit.
+    if ([[Branch getInstance] application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
+        return YES;
+    }

--- a/lib/assets/patches/OpenUrlSourceApplication.swift
+++ b/lib/assets/patches/OpenUrlSourceApplication.swift
@@ -1,0 +1,4 @@
+        // TODO: Adjust your method as you see fit.
+        if Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation) {
+            return true
+        }

--- a/lib/assets/patches/continue_user_activity_new_objc.yml
+++ b/lib/assets/patches/continue_user_activity_new_objc.yml
@@ -1,0 +1,2 @@
+mode: prepend
+text_file: ContinueUserActivityNew.m

--- a/lib/assets/patches/continue_user_activity_new_swift.yml
+++ b/lib/assets/patches/continue_user_activity_new_swift.yml
@@ -1,0 +1,2 @@
+mode: prepend
+text_file: ContinueUserActivityNew.swift

--- a/lib/assets/patches/continue_user_activity_objc.yml
+++ b/lib/assets/patches/continue_user_activity_objc.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: ContinueUserActivity.m

--- a/lib/assets/patches/continue_user_activity_swift.yml
+++ b/lib/assets/patches/continue_user_activity_swift.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: ContinueUserActivity.swift

--- a/lib/assets/patches/did_finish_launching_new_objc.yml
+++ b/lib/assets/patches/did_finish_launching_new_objc.yml
@@ -1,10 +1,2 @@
 mode: append
-text: |
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
-    return YES;
-}
+text_file: DidFinishLaunchingNew.m

--- a/lib/assets/patches/did_finish_launching_new_objc.yml
+++ b/lib/assets/patches/did_finish_launching_new_objc.yml
@@ -1,0 +1,10 @@
+mode: append
+text: |
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+    return YES;
+}

--- a/lib/assets/patches/did_finish_launching_new_swift.yml
+++ b/lib/assets/patches/did_finish_launching_new_swift.yml
@@ -1,0 +1,11 @@
+mode: append
+text: |
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+        return true
+    }

--- a/lib/assets/patches/did_finish_launching_new_swift.yml
+++ b/lib/assets/patches/did_finish_launching_new_swift.yml
@@ -1,11 +1,2 @@
 mode: append
-text: |
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
-        return true
-    }
+text_file: DidFinishLaunchingNew.swift

--- a/lib/assets/patches/did_finish_launching_new_test_objc.yml
+++ b/lib/assets/patches/did_finish_launching_new_test_objc.yml
@@ -1,14 +1,2 @@
 mode: append
-text: |
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-#ifdef DEBUG
-    [Branch setUseTestBranchKey:YES];
-#endif // DEBUG
-
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
-    return YES;
-}
+text_file: DidFinishLaunchingNewTest.m

--- a/lib/assets/patches/did_finish_launching_new_test_objc.yml
+++ b/lib/assets/patches/did_finish_launching_new_test_objc.yml
@@ -1,0 +1,14 @@
+mode: append
+text: |
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
+
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
+    return YES;
+}

--- a/lib/assets/patches/did_finish_launching_new_test_swift.yml
+++ b/lib/assets/patches/did_finish_launching_new_test_swift.yml
@@ -1,14 +1,2 @@
 mode: append
-text: |
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        #if DEBUG
-            Branch.setUseTestBranchKey(true)
-        #endif
-
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
-        return true
-    }
+text_file: DidFinishLaunchingNewTest.swift

--- a/lib/assets/patches/did_finish_launching_new_test_swift.yml
+++ b/lib/assets/patches/did_finish_launching_new_test_swift.yml
@@ -1,0 +1,14 @@
+mode: append
+text: |
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }
+        return true
+    }

--- a/lib/assets/patches/did_finish_launching_objc.yml
+++ b/lib/assets/patches/did_finish_launching_objc.yml
@@ -1,0 +1,6 @@
+mode: append
+text: |
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];

--- a/lib/assets/patches/did_finish_launching_objc.yml
+++ b/lib/assets/patches/did_finish_launching_objc.yml
@@ -1,6 +1,2 @@
 mode: append
-text: |
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
+text_file: DidFinishLaunching.m

--- a/lib/assets/patches/did_finish_launching_swift.yml
+++ b/lib/assets/patches/did_finish_launching_swift.yml
@@ -1,0 +1,7 @@
+mode: append
+text: |
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }

--- a/lib/assets/patches/did_finish_launching_swift.yml
+++ b/lib/assets/patches/did_finish_launching_swift.yml
@@ -1,7 +1,2 @@
 mode: append
-text: |
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
+text_file: DidFinishLaunching.swift

--- a/lib/assets/patches/did_finish_launching_test_objc.yml
+++ b/lib/assets/patches/did_finish_launching_test_objc.yml
@@ -1,10 +1,2 @@
 mode: append
-text: |
-#ifdef DEBUG
-    [Branch setUseTestBranchKey:YES];
-#endif // DEBUG
-
-    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-        // TODO: Route Branch links
-    }];
+text_file: DidFinishLaunchingTest.m

--- a/lib/assets/patches/did_finish_launching_test_objc.yml
+++ b/lib/assets/patches/did_finish_launching_test_objc.yml
@@ -1,0 +1,10 @@
+mode: append
+text: |
+#ifdef DEBUG
+    [Branch setUseTestBranchKey:YES];
+#endif // DEBUG
+
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];

--- a/lib/assets/patches/did_finish_launching_test_swift.yml
+++ b/lib/assets/patches/did_finish_launching_test_swift.yml
@@ -1,5 +1,5 @@
 mode: append
-text: |
+text: >+
         #if DEBUG
             Branch.setUseTestBranchKey(true)
         #endif

--- a/lib/assets/patches/did_finish_launching_test_swift.yml
+++ b/lib/assets/patches/did_finish_launching_test_swift.yml
@@ -1,11 +1,2 @@
 mode: append
-text: >+
-        #if DEBUG
-            Branch.setUseTestBranchKey(true)
-        #endif
-
-        Branch.getInstance().initSession(launchOptions: launchOptions) {
-            universalObject, linkProperties, error in
-
-            // TODO: Route Branch links
-        }
+text_file: DidFinishLaunchingTest.swift

--- a/lib/assets/patches/did_finish_launching_test_swift.yml
+++ b/lib/assets/patches/did_finish_launching_test_swift.yml
@@ -1,0 +1,11 @@
+mode: append
+text: |
+        #if DEBUG
+            Branch.setUseTestBranchKey(true)
+        #endif
+
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
+            universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
+        }

--- a/lib/assets/patches/open_url_new_objc.yml
+++ b/lib/assets/patches/open_url_new_objc.yml
@@ -1,0 +1,2 @@
+mode: prepend
+text_file: OpenUrlNew.m

--- a/lib/assets/patches/open_url_new_swift.yml
+++ b/lib/assets/patches/open_url_new_swift.yml
@@ -1,0 +1,2 @@
+mode: prepend
+text_file: OpenUrlNew.swift

--- a/lib/assets/patches/open_url_objc.yml
+++ b/lib/assets/patches/open_url_objc.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: OpenUrl.m

--- a/lib/assets/patches/open_url_source_application_objc.yml
+++ b/lib/assets/patches/open_url_source_application_objc.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: OpenUrlSourceApplication.m

--- a/lib/assets/patches/open_url_source_application_swift.yml
+++ b/lib/assets/patches/open_url_source_application_swift.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: OpenUrlSourceApplication.swift

--- a/lib/assets/patches/open_url_swift.yml
+++ b/lib/assets/patches/open_url_swift.yml
@@ -1,0 +1,2 @@
+mode: append
+text_file: OpenUrl.swift

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -98,7 +98,7 @@ module BranchIOCLI
             # method does not exist. add it.
             patch_name += "new_"
             patch_name += "test_" if config.keys.count <= 1 || has_multiple_info_plists?
-            patch_name += "swift"
+            patch_name += "objc"
             patch = load_patch patch_name
             patch.regexp = /^@implementation.*?\n/m
           end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -69,14 +69,14 @@ module BranchIOCLI
           patch_name = "did_finish_launching_"
           if app_delegate_swift =~ /didFinishLaunching[^\n]+?\{/m
             # method already present
-            patch_name += "test_" if config.keys.count <= 1 || has_multiple_info_plists?
+            patch_name += "test_" unless config.keys.count <= 1 || has_multiple_info_plists?
             patch_name += "swift"
             patch = load_patch patch_name
             patch.regexp = /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m
           else
             # method not present. add entire method
             patch_name += "new_"
-            patch_name += "test_" if config.keys.count <= 1 || has_multiple_info_plists?
+            patch_name += "test_" unless config.keys.count <= 1 || has_multiple_info_plists?
             patch_name += "swift"
             patch = load_patch patch_name
             patch.regexp = /var\s+window\s?:\s?UIWindow\?.*?\n/m
@@ -90,14 +90,14 @@ module BranchIOCLI
           patch_name = "did_finish_launching_"
           if app_delegate_objc =~ /didFinishLaunchingWithOptions/m
             # method exists. patch it.
-            patch_name += "test_" if config.keys.count <= 1 || has_multiple_info_plists?
+            patch_name += "test_" unless config.keys.count <= 1 || has_multiple_info_plists?
             patch_name += "objc"
             patch = load_patch patch_name
             patch.regexp = /didFinishLaunchingWithOptions.*?\{[^\n]*\n/m
           else
             # method does not exist. add it.
             patch_name += "new_"
-            patch_name += "test_" if config.keys.count <= 1 || has_multiple_info_plists?
+            patch_name += "test_" unless config.keys.count <= 1 || has_multiple_info_plists?
             patch_name += "objc"
             patch = load_patch patch_name
             patch.regexp = /^@implementation.*?\n/m

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -112,7 +112,7 @@ module BranchIOCLI
             # Has application:openURL:options:
             patch_name += "swift"
             patch = load_patch patch_name
-            patch.regexp = /application.*open\s+url.*options:.*?\{.*?\n/m,
+            patch.regexp = /application.*open\s+url.*options:.*?\{.*?\n/m
           elsif app_delegate_swift =~ /application.*open\s+url.*sourceApplication/
             # Has application:openURL:sourceApplication:annotation:
             # TODO: This method is deprecated.


### PR DESCRIPTION
Moved all formatted multiline source patches out of heredocs in the PatchHelper into lib/assets/patches. This uses pattern_patch 0.3.0 with a `text_file` option that allows the source patches to be externalized.

There are still some issues with representing certain types of regular expression (particularly multiline regexps ending in `m`) as strings in YAML. For now, the regexps are still set in the PatchHelper.

This simplifies that code unit immensely.