### PR TITLE
Swift improvements

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -194,7 +194,6 @@ EOF
 
         return true unless File.exist?(lockfile_path) && File.exist?(manifest_path)
 
-        podfile = Pod::Podfile.from_file Pathname.new config.podfile_path
         lockfile = Pod::Lockfile.from_file Pathname.new lockfile_path
         manifest = Pod::Lockfile.from_file Pathname.new manifest_path
 
@@ -206,7 +205,7 @@ EOF
         # compare checksum of Podfile with checksum in Podfile.lock
         # This is a good sanity check, but perhaps unnecessary. It means pod install
         # has not been run since the Podfile was modified, which is probably an oversight.
-        return true unless lockfile.to_hash["PODFILE CHECKSUM"] == podfile.checksum
+        return true unless lockfile.to_hash["PODFILE CHECKSUM"] == config.podfile.checksum
 
         false
       end

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -218,7 +218,7 @@ EOF
 
         header += "\nTarget #{config.target.name}:\n"
         header += " Deployment target: #{config.target.deployment_target}\n"
-        header += " Modules #{config.modules_enabled? ? '' : 'not '}enabled"
+        header += " Modules #{config.modules_enabled? ? '' : 'not '}enabled\n"
         header += " Swift #{config.swift_version}\n" if config.swift_version
         header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -218,6 +218,7 @@ EOF
 
         header += "\nTarget #{config.target.name}:\n"
         header += " Deployment target: #{config.target.deployment_target}\n"
+        header += " Modules #{config.modules_enabled? ? "" : "not "}enabled"
         header += " Swift #{config.swift_version}\n" if config.swift_version
         header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -218,7 +218,7 @@ EOF
 
         header += "\nTarget #{config.target.name}:\n"
         header += " Deployment target: #{config.target.deployment_target}\n"
-        header += " Modules #{config.modules_enabled? ? "" : "not "}enabled"
+        header += " Modules #{config.modules_enabled? ? '' : 'not '}enabled"
         header += " Swift #{config.swift_version}\n" if config.swift_version
         header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -216,7 +216,10 @@ EOF
 
         header += `xcodebuild -version`
 
-        header += "\nTarget #{config.target.name} deploy target: #{config.target.deployment_target}\n"
+        header += "\nTarget #{config.target.name}:\n"
+        header += " Deployment target: #{config.target.deployment_target}\n"
+        header += " Swift #{config.swift_version}\n" if config.swift_version
+        header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
 
         if config.podfile_path
           begin

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -172,6 +172,15 @@ EOF
         target_definition.uses_frameworks?
       end
 
+      # TODO: How many of these can vary by configuration?
+
+      def modules_enabled?
+        return nil unless target
+        setting = target.resolved_build_setting("CLANG_ENABLE_MODULES")["Release"]
+        return nil unless setting
+        setting == "YES"
+      end
+
       def bridging_header_path
         return nil unless target
         path = helper.expanded_build_setting target, "SWIFT_OBJC_BRIDGING_HEADER", "Release"

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -1,3 +1,4 @@
+require "cocoapods-core"
 require "pathname"
 require "xcodeproj"
 
@@ -12,6 +13,7 @@ module BranchIOCLI
       attr_reader :xcodeproj
       attr_reader :xcodeproj_path
       attr_reader :target
+      attr_reader :podfile
       attr_reader :podfile_path
       attr_reader :cartfile_path
       attr_reader :sdk_integration_mode
@@ -120,43 +122,46 @@ EOF
         # Disable Podfile/Cartfile update if --no-add-sdk is present
         return unless sdk_integration_mode.nil?
 
-        # Was --podfile/--cartfile used?
-        if buildfile_path
-          # Yes: Validate. Prompt if not valid.
-          loop do
-            valid = buildfile_path =~ %r{/?#{filename}$}
-            say "#{filename} path must end in /#{filename}." unless valid
-
-            if valid
-              valid = File.exist? buildfile_path
-              say "#{buildfile_path} not found." unless valid
-            end
-
-            if valid
-              if filename == "Podfile"
-                @podfile_path = buildfile_path
-              else
-                @cartfile_path = buildfile_path
-              end
-              return
-            end
-
-            buildfile_path = ask "Please enter the path to your #{filename}: "
-          end
+        # No --podfile or --cartfile option
+        if buildfile_path.nil?
+          # Check for Podfile/Cartfile next to workspace or project
+          buildfile_path = File.expand_path "../#{filename}", (workspace_path || xcodeproj_path)
+          buildfile_path = nil unless File.exist? buildfile_path
         end
 
-        # No: Check for Podfile/Cartfile next to workspace or project
-        buildfile_path = File.expand_path "../#{filename}", (workspace_path || xcodeproj_path)
-        return unless File.exist? buildfile_path
-
-        # Exists: Use it (valid if found)
-        if filename == "Podfile"
-          @podfile_path = buildfile_path
-        else
-          @cartfile_path = buildfile_path
+        # Validate. Prompt if not valid.
+        while !buildfile_path || !validate_buildfile_at_path(buildfile_path, filename)
+          buildfile_path = ask "Please enter the path to your #{filename}: "
         end
 
         @sdk_integration_mode = filename == "Podfile" ? :cocoapods : :carthage
+      end
+
+      def open_podfile(path)
+        @podfile = Pod::Podfile.from_file path
+        @podfile_path = path
+        true
+      rescue RuntimeError => e
+        say e.message
+        false
+      end
+
+      def validate_buildfile_at_path(buildfile_path, filename)
+        valid = buildfile_path =~ %r{/?#{filename}$}
+        say "#{filename} path must end in /#{filename}." unless valid
+
+        if valid
+          valid = File.exist? buildfile_path
+          say "#{buildfile_path} not found." unless valid
+        end
+
+        if filename == "Podfile" && open_podfile(buildfile_path)
+          true
+        elsif filename == "Cartfile"
+          @cartfile_path = buildfile_path
+          true
+        end
+        false
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -126,7 +126,7 @@ EOF
         if buildfile_path.nil?
           # Check for Podfile/Cartfile next to workspace or project
           buildfile_path = File.expand_path "../#{filename}", (workspace_path || xcodeproj_path)
-          buildfile_path = nil unless File.exist? buildfile_path
+          return unless File.exist? buildfile_path
         end
 
         # Validate. Prompt if not valid.

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -160,8 +160,9 @@ EOF
         elsif filename == "Cartfile"
           @cartfile_path = buildfile_path
           true
+        else
+          false
         end
-        false
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -164,6 +164,25 @@ EOF
           false
         end
       end
+
+      def uses_frameworks?
+        return nil unless podfile
+        target_definition = podfile.target_definition_list.find { |t| t.name == config.target.name }
+        return nil unless target_definition
+        target_definition.uses_frameworks?
+      end
+
+      def bridging_header_path
+        return nil unless target
+        path = helper.expanded_build_setting target, "SWIFT_OBJC_BRIDGING_HEADER", "Release"
+        return nil unless path
+        File.expand_path path, File.dirname(xcodeproj_path)
+      end
+
+      def swift_version
+        return nil unless target
+        target.resolved_build_setting("SWIFT_VERSION")["Release"]
+      end
     end
   end
 end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -167,7 +167,7 @@ EOF
 
       def uses_frameworks?
         return nil unless podfile
-        target_definition = podfile.target_definition_list.find { |t| t.name == config.target.name }
+        target_definition = podfile.target_definition_list.find { |t| t.name == target.name }
         return nil unless target_definition
         target_definition.uses_frameworks?
       end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -55,7 +55,7 @@ module BranchIOCLI
 
       def log
         super
-        say <<EOF
+        message = <<-EOF
 <%= color('Xcode project:', BOLD) %> #{xcodeproj_path}
 <%= color('Target:', BOLD) %> #{target.name}
 <%= color('Live key:', BOLD) %> #{keys[:live] || '(none)'}
@@ -72,11 +72,17 @@ module BranchIOCLI
 <%= color('Patch source:', BOLD) %> #{patch_source.inspect}
 <%= color('Commit:', BOLD) %> #{commit.inspect}
 <%= color('SDK integration mode:', BOLD) %> #{sdk_integration_mode || '(none)'}
-<% if swift_version %>
-  <%= color('Swift version: ', BOLD) %> #{swift_version}
-<% end %>
+        EOF
 
-EOF
+        if swift_version
+          message += <<-EOF
+<%= color('Swift version:', BOLD) %> #{swift_version}
+          EOF
+        end
+
+        message += "\n"
+
+        say message
       end
 
       def validate_keys_from_setup_options(options)

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -72,6 +72,9 @@ module BranchIOCLI
 <%= color('Patch source:', BOLD) %> #{patch_source.inspect}
 <%= color('Commit:', BOLD) %> #{commit.inspect}
 <%= color('SDK integration mode:', BOLD) %> #{sdk_integration_mode || '(none)'}
+<% if swift_version %>
+  <%= color('Swift version: ', BOLD) %> #{swift_version}
+<% end %>
 
 EOF
       end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -41,7 +41,7 @@ module BranchIOCLI
           if bridging_header_required?
             unless config.bridging_header_path
               say "Modules not available and bridging header not found. Cannot import Branch."
-              say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-add-sdk."
+              say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
               exit(-1)
               return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
             end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -43,10 +43,11 @@ module BranchIOCLI
               say "Modules not available and bridging header not found. Cannot import Branch."
               say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
               exit(-1)
-              # TODO: Handle exceptions here.
-              bridging_header = File.read bridging_header_path
-              return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
             end
+
+            # TODO: Handle exceptions here.
+            bridging_header = File.read bridging_header_path
+            return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
 
             say "Patching #{bridging_header_path}"
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -39,17 +39,17 @@ module BranchIOCLI
           app_delegate = File.read app_delegate_swift_path
 
           if bridging_header_required?
-            unless config.bridging_header_path
+            unless bridging_header_path
               say "Modules not available and bridging header not found. Cannot import Branch."
               say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
               exit(-1)
               return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
             end
 
-            say "Patching #{config.bridging_header_path}"
+            say "Patching #{bridging_header_path}"
 
-            load_patch(:objc_import).apply config.bridging_header_path
-            helper.add_change config.bridging_header_path
+            load_patch(:objc_import).apply bridging_header_path
+            helper.add_change bridging_header_path
           else
             return false if app_delegate =~ /^\s*import\s+Branch/
             load_patch(:swift_import).apply app_delegate_swift_path

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -43,7 +43,9 @@ module BranchIOCLI
               say "Modules not available and bridging header not found. Cannot import Branch."
               say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
               exit(-1)
-              return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
+              # TODO: Handle exceptions here.
+              bridging_header = File.read bridging_header_path
+              return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
             end
 
             say "Patching #{bridging_header_path}"


### PR DESCRIPTION
The `setup` command now determines whether to use a Swift import in the AppDelegate or an Objective-C import in a bridging header.

New information was added to the report command: Swift version, whether modules are enabled and path to bridging header.