### PR TITLE
Bridging header fixes

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -49,13 +49,13 @@ EOF
           report.write "#{report_header}\n"
 
           # run xcodebuild -list
-          sh "#{base_xcodebuild_cmd} -list", report
+          report.log_command "#{base_xcodebuild_cmd} -list"
 
           # If using a workspace, -list all the projects as well
           if config.workspace_path
             config.workspace.file_references.map(&:path).each do |project_path|
               path = File.join File.dirname(config.workspace_path), project_path
-              sh "xcodebuild -list -project #{path}", report
+              report.log_command "xcodebuild -list -project #{path}"
             end
           end
 
@@ -64,7 +64,7 @@ EOF
           base_cmd = "#{base_cmd} -scheme #{config.scheme}" if config.workspace_path
 
           # xcodebuild -showBuildSettings
-          sh "#{base_cmd} -showBuildSettings", report
+          report.log_command "#{base_cmd} -showBuildSettings"
 
           # Add more options for the rest of the commands
           base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
@@ -72,11 +72,11 @@ EOF
 
           if config.clean
             say "Cleaning"
-            sh "#{base_cmd} clean", report
+            report.log_command "#{base_cmd} clean"
           end
 
           say "Building"
-          sh "#{base_cmd} -verbose", report
+          report.log_command "#{base_cmd} -verbose"
 
           say "Done ✅"
         end

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -20,23 +20,6 @@ module BranchIOCLI
 
         xcodeproj = config.xcodeproj
 
-        case config.sdk_integration_mode
-        when :cocoapods
-          if File.exist? config.podfile_path
-            helper.update_podfile options
-          else
-            helper.add_cocoapods options
-          end
-        when :carthage
-          if File.exist? config.cartfile_path
-            helper.update_cartfile options, xcodeproj
-          else
-            helper.add_carthage options
-          end
-        when :direct
-          helper.add_direct options
-        end
-
         is_app_target = !config.target.extension_target_type?
 
         if is_app_target && options.validate &&
@@ -59,6 +42,23 @@ module BranchIOCLI
         config_helper.target.add_system_frameworks options.frameworks unless options.frameworks.nil? || options.frameworks.empty?
 
         xcodeproj.save
+
+        case config.sdk_integration_mode
+        when :cocoapods
+          if File.exist? config.podfile_path
+            helper.update_podfile options
+          else
+            helper.add_cocoapods options
+          end
+        when :carthage
+          if File.exist? config.cartfile_path
+            helper.update_cartfile options, xcodeproj
+          else
+            helper.add_carthage options
+          end
+        when :direct
+          helper.add_direct options
+        end
 
         patch_helper.patch_source xcodeproj if options.patch_source
 

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -172,6 +172,14 @@ EOF
         target_definition.uses_frameworks?
       end
 
+      def bridging_header_required?
+        return false unless swift_version
+        # If there is a Podfile and use_frameworks! is not present for this
+        # target, we need a bridging header.
+        return true if podfile && !uses_frameworks?
+        !modules_enabled?
+      end
+
       # TODO: How many of these can vary by configuration?
 
       def modules_enabled?
@@ -182,15 +190,22 @@ EOF
       end
 
       def bridging_header_path
+        return @bridging_header_path if @bridging_header_path
+
         return nil unless target
         path = helper.expanded_build_setting target, "SWIFT_OBJC_BRIDGING_HEADER", "Release"
         return nil unless path
-        File.expand_path path, File.dirname(xcodeproj_path)
+
+        @bridging_header_path = File.expand_path path, File.dirname(xcodeproj_path)
+        @bridging_header_path
       end
 
       def swift_version
+        return @swift_version if @swift_version
+
         return nil unless target
-        target.resolved_build_setting("SWIFT_VERSION")["Release"]
+        @swift_version = target.resolved_build_setting("SWIFT_VERSION")["Release"]
+        @swift_version
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -176,8 +176,7 @@ EOF
         return false unless swift_version
         # If there is a Podfile and use_frameworks! is not present for this
         # target, we need a bridging header.
-        return true if podfile && !uses_frameworks?
-        !modules_enabled?
+        podfile && !uses_frameworks?
       end
 
       # TODO: How many of these can vary by configuration?

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -28,6 +28,29 @@ module BranchIOCLI
           !config.modules_enabled?
         end
 
+        def patch_bridging_header
+          unless bridging_header_path
+            say "Modules not available and bridging header not found. Cannot import Branch."
+            say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
+            exit(-1)
+          end
+
+          begin
+            bridging_header = File.read bridging_header_path
+            return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
+          rescue RuntimeError => e
+            say e.message
+            say "Cannot read #{bridging_header_path}."
+            say "Please correct this setting or use --no-patch-source."
+            exit(-1)
+          end
+
+          say "Patching #{bridging_header_path}"
+
+          load_patch(:objc_import).apply bridging_header_path
+          helper.add_change bridging_header_path
+        end
+
         def patch_app_delegate_swift(project)
           return false unless config.swift_version
 
@@ -39,20 +62,7 @@ module BranchIOCLI
           app_delegate = File.read app_delegate_swift_path
 
           if bridging_header_required?
-            unless bridging_header_path
-              say "Modules not available and bridging header not found. Cannot import Branch."
-              say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
-              exit(-1)
-            end
-
-            # TODO: Handle exceptions here.
-            bridging_header = File.read bridging_header_path
-            return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
-
-            say "Patching #{bridging_header_path}"
-
-            load_patch(:objc_import).apply bridging_header_path
-            helper.add_change bridging_header_path
+            patch_bridging_header
           else
             return false if app_delegate =~ /^\s*import\s+Branch/
             load_patch(:swift_import).apply app_delegate_swift_path

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -21,34 +21,27 @@ module BranchIOCLI
           helper.add_change change
         end
 
-        def bridging_header_required?
-          # If there is a Podfile and use_frameworks! is not present for this
-          # target, we need a bridging header.
-          return true if config.podfile && !config.uses_frameworks?
-          !config.modules_enabled?
-        end
-
         def patch_bridging_header
-          unless bridging_header_path
+          unless config.bridging_header_path
             say "Modules not available and bridging header not found. Cannot import Branch."
             say "Please add use_frameworks! to your Podfile and/or enable modules in your project or use --no-patch-source."
             exit(-1)
           end
 
           begin
-            bridging_header = File.read bridging_header_path
+            bridging_header = File.read config.bridging_header_path
             return false if bridging_header =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}
           rescue RuntimeError => e
             say e.message
-            say "Cannot read #{bridging_header_path}."
+            say "Cannot read #{config.bridging_header_path}."
             say "Please correct this setting or use --no-patch-source."
             exit(-1)
           end
 
-          say "Patching #{bridging_header_path}"
+          say "Patching #{config.bridging_header_path}"
 
-          load_patch(:objc_import).apply bridging_header_path
-          helper.add_change bridging_header_path
+          load_patch(:objc_import).apply config.bridging_header_path
+          helper.add_change config.bridging_header_path
         end
 
         def patch_app_delegate_swift(project)
@@ -61,10 +54,10 @@ module BranchIOCLI
 
           app_delegate = File.read app_delegate_swift_path
 
-          if bridging_header_required?
-            patch_bridging_header
-          else
-            return false if app_delegate =~ /^\s*import\s+Branch/
+          # Can't check for the import here, since there may be a bridging header.
+          return false if app_delegate =~ /Branch\.initSession/
+
+          unless config.bridging_header_required?
             load_patch(:swift_import).apply app_delegate_swift_path
           end
 
@@ -262,6 +255,10 @@ module BranchIOCLI
         end
 
         def patch_source(xcodeproj)
+          # Patch the bridging header any time Swift imports are not available,
+          # to make Branch available throughout the app, whether the AppDelegate
+          # is in Swift or Objective-C.
+          patch_bridging_header if config.bridging_header_required?
           patch_app_delegate_swift(xcodeproj) || patch_app_delegate_objc(xcodeproj)
         end
       end


### PR DESCRIPTION
Refactored and corrected the bridging header patch. This still requires at least one import in the bridging header in order to work correctly. Otherwise it's more involved to determine where to insert the import, since there may be an include guard. This will be fixed soon.

Fixed a bug in the report command. If a logged command failed, an exception was raised rather than logging to the report.