### PR TITLE
Branch report

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -308,22 +308,36 @@ EOF
         begin
           info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
           branch_key = info_plist["branch_key"]
-          report += " Branch key(s):\n"
+          report += " Branch key(s) (Info.plist):\n"
           if branch_key.kind_of? Hash
             branch_key.each_key do |key|
               report += "  #{key.capitalize}: #{branch_key[key]}\n"
             end
-          else
+          elsif branch_key
             report += "  #{branch_key}\n"
+          else
+            report += "  (none found)\n"
+          end
+
+          branch_universal_link_domains = info_plist["branch_universal_link_domains"]
+          if branch_universal_link_domains
+            if branch_universal_link_domains.kind_of? Array
+              report += " branch_universal_link_domains (Info.plist):\n"
+              branch_universal_link_domains.each do |domain|
+                report += "  #{domain}\n"
+              end
+            else
+              report += " branch_universal_link_domains (Info.plist): #{branch_universal_link_domains}\n"
+            end
           end
         rescue StandardError => e
-          report += " (Failed to get Branch key from Info.plist: #{e.message})\n"
+          report += " (Failed to open Info.plist: #{e.message})\n"
         end
 
         unless config.target.extension_target_type?
           begin
             domains = helper.domains_from_project config.configuration
-            report += " Universal Link domains:\n"
+            report += " Universal Link domains (entitlements):\n"
             domains.each do |domain|
               report += "  #{domain}\n"
             end

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -244,9 +244,7 @@ EOF
             header += "\n"
           end
 
-          # Already verified existence.
-          podfile = Pod::Podfile.from_file Pathname.new config.podfile_path
-          target_definition = podfile.target_definitions[config.target.name]
+          target_definition = config.podfile.target_definitions[config.target.name]
           if target_definition
             branch_deps = target_definition.dependencies.select { |p| p.name =~ %r{^(Branch|Branch-SDK)(/.*)?$} }
             header += "Podfile target #{target_definition.name}:"

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -294,16 +294,9 @@ EOF
 
       # String containing information relevant to Branch setup
       def branch_report
-        bundle_identifier = helper.expanded_build_setting config.target, "PRODUCT_BUNDLE_IDENTIFIER", config.configuration
-        dev_team = helper.expanded_build_setting config.target, "DEVELOPMENT_TEAM", config.configuration
         infoplist_path = helper.expanded_build_setting config.target, "INFOPLIST_FILE", config.configuration
-        entitlements_path = helper.expanded_build_setting config.target, "CODE_SIGN_ENTITLEMENTS", config.configuration
 
         report = "Branch configuration:\n"
-        report += " PRODUCT_BUNDLE_IDENTIFIER = #{bundle_identifier.inspect}\n"
-        report += " DEVELOPMENT_TEAM = #{dev_team.inspect}\n"
-        report += " INFOPLIST_PATH = #{infoplist_path.inspect}\n"
-        report += " CODE_SIGN_ENTITLEMENTS = #{entitlements_path.inspect}\n"
 
         begin
           info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -82,8 +82,6 @@ EOF
           say "Done ✅"
         end
 
-        obfuscate_report
-
         say "Report generated in #{config.report_path}"
       end
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -322,14 +322,16 @@ EOF
           report += " (Failed to get Branch key from Info.plist: #{e.message})\n"
         end
 
-        begin
-          domains = helper.domains_from_project config.configuration
-          report += " Universal Link domains:\n"
-          domains.each do |domain|
-            report += "  #{domain}\n"
+        unless config.target.extension_target_type?
+          begin
+            domains = helper.domains_from_project config.configuration
+            report += " Universal Link domains:\n"
+            domains.each do |domain|
+              report += "  #{domain}\n"
+            end
+          rescue StandardError => e
+            report += " (Failed to get Universal Link domains from entitlements file: #{e.message})\n"
           end
-        rescue StandardError => e
-          report += " (Failed to get Universal Link domains from entitlements file: #{e.message})\n"
         end
 
         report

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -304,7 +304,7 @@ EOF
           report += " Branch key(s):\n"
           if branch_key.kind_of? Hash
             branch_key.each_key do |key|
-              report += "  #{key.capitalize}: #{branch_keys[key]}\n"
+              report += "  #{key.capitalize}: #{branch_key[key]}\n"
             end
           else
             report += "  #{branch_key}\n"

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -219,11 +219,20 @@ EOF
 
         header += `xcodebuild -version`
 
+        bundle_identifier = helper.expanded_build_setting config.target, "PRODUCT_BUNDLE_IDENTIFIER", config.configuration
+        dev_team = helper.expanded_build_setting config.target, "DEVELOPMENT_TEAM", config.configuration
+        infoplist_path = helper.expanded_build_setting config.target, "INFOPLIST_FILE", config.configuration
+        entitlements_path = helper.expanded_build_setting config.target, "CODE_SIGN_ENTITLEMENTS", config.configuration
+
         header += "\nTarget #{config.target.name}:\n"
+        header += " Bundle identifier: #{bundle_identifier || '(none)'}\n"
+        header += " Development team: #{dev_team || '(none)'}\n"
         header += " Deployment target: #{config.target.deployment_target}\n"
         header += " Modules #{config.modules_enabled? ? '' : 'not '}enabled\n"
         header += " Swift #{config.swift_version}\n" if config.swift_version
         header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
+        header += " Info.plist: #{infoplist_path || '(none)'}\n"
+        header += " Entitlements file: #{entitlements_path || '(none)'}\n"
 
         if config.podfile_path
           begin

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -91,7 +91,7 @@ module BranchIOCLI
         choice = choose do |menu|
           menu.header = "There are uncommitted changes in this repo. It's best to stash or commit them before continuing."
           menu.choice "Stash"
-          menu.choice "Commit (you will be prompted for a commit message)"
+          menu.choice "Commit (You will be prompted for a commit message.)"
           menu.choice "Quit"
           menu.choice "Ignore and continue"
           menu.prompt = "Please enter one of the options above: "

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -93,6 +93,7 @@ module BranchIOCLI
           menu.choice "Stash"
           menu.choice "Commit (you will be prompted for a commit message)"
           menu.choice "Quit"
+          menu.choice "Ignore and continue"
           menu.prompt = "Please enter one of the options above: "
         end
 
@@ -102,7 +103,7 @@ module BranchIOCLI
         when /^Commit/
           message = ask "Please enter a commit message: "
           sh "git commit -aqm #{Shellwords.escape(message)}"
-        else
+        when /^Quit/
           say "Please stash or commit your changes before continuing."
           exit(-1)
         end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -651,7 +651,7 @@ EOF
           exit(-1)
         end
 
-        gem_home = ENV["GEM_HOME"]
+        gem_home = Gem.dir
         if gem_home && File.writable?(gem_home)
           sh "gem install cocoapods"
         else


### PR DESCRIPTION
Added an "Ignore and continue" option to the list of choices when the setup command detects uncommitted changes in a git repo.

Added a section to the report with Branch configuration, including the `branch_key` and `branch_universal_link_domains` from the Info.plist and the `applinks:` domains from the entitlements file.

Also added some general information: bundle identifier, signing team, location of Info.plist and entitlements files.