### PR TITLE
Report pbxreferenceproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ report with additional diagnostic information suitable for opening a support tic
 |--configuration Debug/Release/CustomConfig|Name of a build configuration (default: Release)|
 |--sdk iphonesimulator|Name of an SDK to use with xcodebuild (default: iphonesimulator)|
 |--[no-]clean|Clean before building (default: yes)|
-|--[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|
+|-H, --[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _branch_io_complete()
 
     validate_opts="$global_opts -D --domains --xcodeproj --target"
 
-    report_opts="$global_opts --xcodeproj --workspace --header-only --no-clean --scheme --target --configuration --sdk --out"
+    report_opts="$global_opts --xcodeproj --workspace -H --header-only --no-clean --scheme --target --configuration --sdk --out"
     report_opts="$report_opts --podfile --cartfile --no-pod-repo-update"
 
     if [[ ${cur} == -* ]] ; then

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -167,7 +167,7 @@ EOF
         c.option "--podfile /path/to/Podfile", String, "Path to the Podfile for the project"
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
-        c.option "--[no-]header-only", "Write a report header to standard output and exit"
+        c.option "-H", "--[no-]header-only", "Write a report header to standard output and exit"
         c.option "--[no-]pod-repo-update", "Update the local podspec repo before installing (default: yes)"
         c.option "--out ./report.txt", String, "Report output path (default: ./report.txt)"
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -15,7 +15,9 @@ module BranchIOCLI
       def run!
         say "\n"
 
-        load_settings_from_xcode
+        unless load_settings_from_xcode
+          say "Failed to load settings from Xcode. Some information may be missing.\n"
+        end
 
         if config.header_only
           say report_header
@@ -390,6 +392,7 @@ EOF
             @xcode_settings[matches[1]] = matches[2]
           end
           @xcodebuild_showbuildsettings_status = thread.value
+          return @xcodebuild_showbuildsettings_status.success?
         end
       end
     end

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -1,5 +1,6 @@
 require "cocoapods-core"
 require "branch_io_cli/helper/methods"
+require "open3"
 require "plist"
 
 module BranchIOCLI
@@ -12,6 +13,8 @@ module BranchIOCLI
 
       def run!
         say "\n"
+
+        load_settings_from_xcode
 
         if config.header_only
           say report_header
@@ -65,7 +68,13 @@ EOF
           base_cmd = "#{base_cmd} -scheme #{config.scheme}" if config.workspace_path
 
           # xcodebuild -showBuildSettings
-          report.log_command "#{base_cmd} -showBuildSettings"
+          report.write "$ #{base_cmd} -showBuildSettings\n\n"
+          report.write @xcodebuild_showbuildsettings_output
+          if @xcodebuild_showbuildsettings_status.success?
+            report.write "Success.\n\n"
+          else
+            report.write "#{@xcodebuild_showbuildsettings_status}.\n\n"
+          end
 
           # Add more options for the rest of the commands
           base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
@@ -146,7 +155,11 @@ EOF
       def version_from_branch_framework
         framework = config.target.frameworks_build_phase.files.find { |f| f.file_ref.path =~ /Branch.framework$/ }
         return nil unless framework
-        framework_path = framework.file_ref.real_path
+        if framework.file_ref.isa == "PBXFileReference"
+          framework_path = framework.file_ref.real_path
+        elsif framework.file_ref.isa == "PBXReferenceProxy" && @xcode_settings
+          framework_path = File.expand_path framework.file_ref.path, @xcode_settings[framework.file_ref.source_tree]
+        end
         info_plist_path = File.join framework_path.to_s, "Info.plist"
         return nil unless File.exist? info_plist_path
 
@@ -347,6 +360,27 @@ EOF
         end
 
         report
+      end
+
+      def built_products_dir
+        @xcode_settings["BUILT_PRODUCTS_DIR"]
+      end
+
+      def load_settings_from_xcode
+        cmd = base_xcodebuild_cmd
+        cmd = "#{cmd} -scheme #{config.scheme}" if config.workspace_path
+        cmd = "#{cmd} -sdk #{config.sdk} -configuration #{config.configuration} -showBuildSettings"
+        @xcodebuild_showbuildsettings_output = ""
+        @xcode_settings = {}
+        Open3.popen2e(cmd) do |stdin, output, thread|
+          while (line = output.gets)
+            @xcodebuild_showbuildsettings_output += line
+            line.strip!
+            next unless (matches = /^(.+)\s+=\s+(.+)$/.match line)
+            @xcode_settings[matches[1]] = matches[2]
+          end
+          @xcodebuild_showbuildsettings_status = thread.value
+        end
       end
     end
   end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -375,18 +375,22 @@ module BranchIOCLI
         setting_value = target.resolved_build_setting(setting_name)[configuration]
         return if setting_value.nil?
 
+        expand_build_settings setting_value, target, configuration
+      end
+
+      def expand_build_settings(string, target, configuration)
         search_position = 0
-        while (matches = /\$\(([^(){}]*)\)|\$\{([^(){}]*)\}/.match(setting_value, search_position))
+        while (matches = /\$\(([^(){}]*)\)|\$\{([^(){}]*)\}/.match(string, search_position))
           macro_name = matches[1] || matches[2]
-          search_position = setting_value.index(macro_name) - 2
+          search_position = string.index(macro_name) - 2
 
           expanded_macro = macro_name == "SRCROOT" ? "." : expanded_build_setting(target, macro_name, configuration)
           search_position += macro_name.length + 3 and next if expanded_macro.nil?
 
-          setting_value.gsub!(/\$\(#{macro_name}\)|\$\{#{macro_name}\}/, expanded_macro)
+          string.gsub!(/\$\(#{macro_name}\)|\$\{#{macro_name}\}/, expanded_macro)
           search_position += expanded_macro.length
         end
-        setting_value
+        string
       end
 
       def add_cocoapods(options)


### PR DESCRIPTION
The report command will now find the Branch.framework through a PBXReferenceProxy (if it is a product built by a subproject, e.g.). It will also find BNCConfig.m in subprojects as well as the main project.

Added `-H` as a synonym for `--header-only` with the report command.