### PR TITLE
Scheme-based builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ report with additional diagnostic information suitable for opening a support tic
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--scheme MyAppScheme|Name of a scheme to build|
-|--configuration Debug/Release/CustomConfig|Name of a build configuration (default: Release)|
+|--configuration Debug/Release/CustomConfig|Name of a build configuration (default: Scheme-dependent)|
 |--sdk iphonesimulator|Name of an SDK to use with xcodebuild (default: iphonesimulator)|
 |--[no-]clean|Clean before building (default: yes)|
 |-H, --[no-]header-only|Show a diagnostic header and exit without cleaning or building (default: no)|

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -162,7 +162,7 @@ EOF
         c.option "--workspace MyProject.xcworkspace", String, "Path to an Xcode workspace"
         c.option "--scheme MyProjectScheme", String, "A scheme from the project or workspace to build"
         c.option "--target MyProjectTarget", String, "A target to build"
-        c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Release)"
+        c.option "--configuration Debug|Release|CustomConfigName", String, "The build configuration to use (default: Scheme-dependent)"
         c.option "--sdk iphonesimulator", String, "Passed as -sdk to xcodebuild (default: iphonesimulator)"
         c.option "--podfile /path/to/Podfile", String, "Path to the Podfile for the project"
         c.option "--cartfile /path/to/Cartfile", String, "Path to the Cartfile for the project"
@@ -175,7 +175,6 @@ EOF
           options.default(
             clean: true,
             header_only: false,
-            configuration: "Release",
             sdk: "iphonesimulator",
             out: "./report.txt",
             pod_repo_update: true

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -67,8 +67,9 @@ EOF
           end
 
           base_cmd = base_xcodebuild_cmd
-          # Add -scheme option for the rest of the commands
+          # Add more options for the rest of the commands
           base_cmd = "#{base_cmd} -scheme #{config.scheme}"
+          base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
 
           # xcodebuild -showBuildSettings
           report.write "$ #{base_cmd} -showBuildSettings\n\n"
@@ -78,9 +79,6 @@ EOF
           else
             report.write "#{@xcodebuild_showbuildsettings_status}.\n\n"
           end
-
-          # Add more options for the rest of the commands
-          base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
 
           if config.clean
             say "Cleaning"
@@ -240,6 +238,7 @@ EOF
         header = "cocoapods-core: #{Pod::CORE_VERSION}\n"
 
         header += `xcodebuild -version`
+        header += "SDK: #{@xcode_settings['SDK_NAME']}\n" if @xcode_settings
 
         bundle_identifier = helper.expanded_build_setting config.target, "PRODUCT_BUNDLE_IDENTIFIER", config.configuration
         dev_team = helper.expanded_build_setting config.target, "DEVELOPMENT_TEAM", config.configuration

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -67,8 +67,8 @@ EOF
           end
 
           base_cmd = base_xcodebuild_cmd
-          # Add -scheme option for the rest of the commands if using a workspace
-          base_cmd = "#{base_cmd} -scheme #{config.scheme}" if config.workspace_path
+          # Add -scheme option for the rest of the commands
+          base_cmd = "#{base_cmd} -scheme #{config.scheme}"
 
           # xcodebuild -showBuildSettings
           report.write "$ #{base_cmd} -showBuildSettings\n\n"
@@ -81,7 +81,6 @@ EOF
 
           # Add more options for the rest of the commands
           base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
-          base_cmd = "#{base_cmd} -target #{config.target}" unless config.workspace_path
 
           if config.clean
             say "Cleaning"
@@ -374,14 +373,9 @@ EOF
         report
       end
 
-      def built_products_dir
-        @xcode_settings["BUILT_PRODUCTS_DIR"]
-      end
-
       def load_settings_from_xcode
-        cmd = base_xcodebuild_cmd
-        cmd = "#{cmd} -scheme #{config.scheme}" if config.workspace_path
-        cmd = "#{cmd} -sdk #{config.sdk} -configuration #{config.configuration} -showBuildSettings"
+        cmd = "#{base_xcodebuild_cmd} -scheme #{config.scheme}"
+        cmd += " -configuration #{config.configuration} -sdk #{config.sdk} -showBuildSettings"
         @xcodebuild_showbuildsettings_output = ""
         @xcode_settings = {}
         Open3.popen2e(cmd) do |stdin, output, thread|

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -174,10 +174,19 @@ EOF
 
         # Look for a shared scheme.
         xcshareddata_path = File.join project_path, "xcshareddata", "xcschemes", "#{@scheme}.xcscheme"
-        scheme = Xcodeproj::XCScheme.new xcshareddata_path if File.exist?(xcshareddata_path)
-        if scheme
-          @configuration = scheme.launch_action.build_configuration
+        scheme_path = xcshareddata_path if File.exist?(xcshareddata_path)
+
+        unless scheme_path
+          # Look for a local scheme
+          user = @xcode_settings["USER"] if @xcode_settings
+          user ||= ENV["USER"] || ENV["LOGNAME"]
+          xcuserdata_path = File.join project_path, "xcuserdata", "#{user}.xcuserdatad", "xcschemes", "#{@scheme}.xcscheme"
+          scheme_path = xcuserdata_path if File.exist?(xcuserdata_path)
         end
+
+        return unless scheme_path
+
+        @configuration = Xcodeproj::XCScheme.new(scheme_path).launch_action.build_configuration
       end
     end
   end

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -18,8 +18,8 @@ module BranchIOCLI
         @pod_repo_update = options.pod_repo_update
 
         validate_xcodeproj_and_workspace options
-        validate_target options
         validate_scheme options
+        validate_target options
         validate_configuration options
 
         # If neither --podfile nor --cartfile is present, arbitrarily look for a Podfile
@@ -132,24 +132,32 @@ EOF
 
       def validate_scheme(options)
         schemes = all_schemes
-        # TODO: Prompt if --scheme specified but not found.
+
         if options.scheme && schemes.include?(options.scheme)
           @scheme = options.scheme
         elsif schemes.count == 1
           @scheme = schemes.first
         elsif !schemes.empty?
-          # By default, take a scheme with the same name as the target name.
-          return if (@scheme = schemes.find { |s| s == target.name })
+          # By default, take a scheme with the same name as the project name.
+          return if (@scheme = schemes.find { |s| s == File.basename(xcodeproj_path, '.xcodeproj') })
 
-          say "Please specify one of the following for the --scheme argument:"
-          schemes.each do |scheme|
-            say " #{scheme}"
+          @scheme = choose do |menu|
+            menu.header = "Schemes from project"
+            schemes.each { |s| menu.choice s }
+            menu.prompt = "Please choose one of the schemes above. "
           end
-          exit 1
         else
           say "No scheme defined in project."
           exit(-1)
         end
+
+        scheme = scheme_with_name @scheme
+        return if options.target || scheme.nil?
+
+        # Find the target used when running the scheme if the user didn't specify one.
+        # This will be picked up in #validate_target
+        entry = scheme.build_action.entries.select(&:build_for_running?).first
+        options.target = entry.buildable_references.first.target_name
       end
 
       def all_schemes
@@ -160,12 +168,7 @@ EOF
         end
       end
 
-      def validate_configuration(options)
-        @configuration = options.configuration
-        return if @configuration
-
-        @configuration = "Debug" # Usual default for the launch action
-
+      def scheme_with_name(scheme_name)
         if workspace_path
           project_path = workspace.schemes[@scheme]
         else
@@ -184,9 +187,33 @@ EOF
           scheme_path = xcuserdata_path if File.exist?(xcuserdata_path)
         end
 
-        return unless scheme_path
+        return nil unless scheme_path
 
-        @configuration = Xcodeproj::XCScheme.new(scheme_path).launch_action.build_configuration
+        Xcodeproj::XCScheme.new(scheme_path)
+      end
+
+      def validate_configuration(options)
+        all_configs = xcodeproj.build_configurations.map(&:name)
+
+        if options.configuration && all_configs.include?(options.configuration)
+          @configuration = options.configuration
+        elsif options.configuration
+          say "Configuration #{options.configuration} not found."
+          @configuration = choose do |menu|
+            menu.header = "Configurations from project"
+            all_configs.each { |c| menu.choice c }
+            menu.prompt = "Please choose one of the above. "
+          end
+        end
+
+        return if @configuration
+
+        @configuration = "Debug" # Usual default for the launch action
+
+        scheme = scheme_with_name @scheme
+        return unless scheme
+
+        @configuration = scheme.launch_action.build_configuration
       end
     end
   end


### PR DESCRIPTION
All builds triggered by the report command are now scheme-based. The CLI now prompts with a list of valid schemes if it cannot infer one or an invalid scheme was passed at the command line. From the scheme it infers the default target and build configuration, which may be overridden using command-line options. The target is not passed to xcodebuild. It is used for other reporting, e.g. finding the Info.plist file.

The report command now also includes the SDK and version used when building.