### PR TITLE
Fixed setting expansion with :rfc1034identifier

### DIFF
--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -402,11 +402,12 @@ module BranchIOCLI
           end
 
           if modifier == "rfc1034identifier"
-            # from the Apple dev portal when creating a new app ID:
+            # From the Apple dev portal when creating a new app ID:
             # You cannot use special characters such as @, &, *, ', "
-            # Also include whitespace and period based on https://stackoverflow.com/a/2468382/875725
-            special_chars = /[\s\.@&*'"]/
-            expanded_macro.gsub!(special_chars, '_')
+            # From trial and error with Xcode, it appears that only letters, digits and hyphens are allowed.
+            # Everything else becomes a hyphen, including underscores.
+            special_chars = /[^A-Za-z0-9-]/
+            expanded_macro.gsub!(special_chars, '-')
           end
 
           search_position += original_macro.length + 3 and next if expanded_macro.nil?

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -384,8 +384,13 @@ module BranchIOCLI
           original_macro = matches[1] || matches[2]
           search_position = string.index(original_macro) - 2
 
-          # ignore modifiers for now
-          macro_name = original_macro.sub(/:.*$/, "")
+          modifier_regexp = /^(.+):(.+)$/
+          if (matches = modifier_regexp.match original_macro)
+            macro_name = matches[1]
+            modifier = matches[2]
+          else
+            macro_name = original_macro
+          end
 
           case macro_name
           when "SRCROOT"
@@ -394,6 +399,14 @@ module BranchIOCLI
             expanded_macro = target.name
           else
             expanded_macro = expanded_build_setting(target, macro_name, configuration)
+          end
+
+          if modifier == "rfc1034identifier"
+            # from the Apple dev portal when creating a new app ID:
+            # You cannot use special characters such as @, &, *, ', "
+            # Also include whitespace and period based on https://stackoverflow.com/a/2468382/875725
+            special_chars = /[\s\.@&*'"]/
+            expanded_macro.gsub!(special_chars, '_')
           end
 
           search_position += original_macro.length + 3 and next if expanded_macro.nil?

--- a/spec/ios_helper_spec.rb
+++ b/spec/ios_helper_spec.rb
@@ -110,7 +110,7 @@ describe BranchIOCLI::Helper::IOSHelper do
     it "recognizes :rfc1034identifier when expanding" do
       expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My App" } }
       expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
-      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My_App"
+      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My-App"
     end
 
     it "ignores any other modifier" do
@@ -120,9 +120,9 @@ describe BranchIOCLI::Helper::IOSHelper do
     end
 
     it "substitutes _ for special characters when :rfc1034identifier is present" do
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My .@*&'\"App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My .@*&'\\\"+%_App" } }
       expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
-      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My_______App"
+      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My-----------App"
     end
   end
 

--- a/spec/ios_helper_spec.rb
+++ b/spec/ios_helper_spec.rb
@@ -42,7 +42,7 @@ describe BranchIOCLI::Helper::IOSHelper do
   end
 
   describe "#expanded_build_setting" do
-    let (:target) { double "target" }
+    let (:target) { double "target", name: "MyTarget" }
     it "expands values delimited by $()" do
       expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE") { { "Release" => "$(SETTING_VALUE)" } }
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE") { { "Release" => "value" } }
@@ -63,6 +63,11 @@ describe BranchIOCLI::Helper::IOSHelper do
     it "substitutes . for $(SRCROOT)" do
       expect(target).to receive(:resolved_build_setting).with("SETTING_USING_SRCROOT") { { "Release" => "$(SRCROOT)/some.file" } }
       expect(instance.expanded_build_setting(target, "SETTING_USING_SRCROOT", "Release")).to eq "./some.file"
+    end
+
+    it "subsitutes the target name for $(TARGET_NAME)" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_USING_TARGET_NAME") { { "Release" => "$(TARGET_NAME)" } }
+      expect(instance.expanded_build_setting(target, "SETTING_USING_TARGET_NAME", "Release")).to eq target.name
     end
 
     it "returns the setting when no macro present" do
@@ -100,6 +105,24 @@ describe BranchIOCLI::Helper::IOSHelper do
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => nil } }
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_BOGUS_VALUE", "Release")).to eq "$(SETTING_VALUE1).value2"
+    end
+
+    it "recognizes :rfc1034identifier when expanding" do
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
+      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My_App"
+    end
+
+    it "ignores any other modifier" do
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:foo)" } }
+      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My App"
+    end
+
+    it "substitutes _ for special characters when :rfc1034identifier is present" do
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My .@*&'\"App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
+      expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My_______App"
     end
   end
 


### PR DESCRIPTION
This is used in some projects to produce an identifier from an arbitrary string by replacing special characters with hyphens. For example, in some apps, `PRODUCT_BUNDLE_IDENTIFIER` is defined as something like `com.example.$(PRODUCT_NAME:rfc1034identifier)`. This turns a `PRODUCT_NAME` like "My App" into "My-App."

This is critical for AASA validation with such apps.