### PR TITLE
Resolve against xcconfig

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -334,10 +334,12 @@ EOF
           report += " Branch key(s) (Info.plist):\n"
           if branch_key.kind_of? Hash
             branch_key.each_key do |key|
-              report += "  #{key.capitalize}: #{branch_key[key]}\n"
+              resolved_key = helper.expand_build_settings branch_key[key], config.target, config.configuration
+              report += "  #{key.capitalize}: #{resolved_key}\n"
             end
           elsif branch_key
-            report += "  #{branch_key}\n"
+            resolved_key = helper.expand_build_settings branch_key, config.target, config.configuration
+            report += "  #{resolved_key}\n"
           else
             report += "  (none found)\n"
           end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -373,7 +373,13 @@ module BranchIOCLI
 
       def expanded_build_setting(target, setting_name, configuration)
         # second arg true means if there is an xcconfig, also consult that
-        setting_value = target.resolved_build_setting(setting_name, true)[configuration]
+        begin
+          setting_value = target.resolved_build_setting(setting_name, true)[configuration]
+        rescue Errno::ENOENT
+          # If not found, look up without it
+          setting_value = target.resolved_build_setting(setting_name, false)[configuration]
+        end
+
         return if setting_value.nil?
 
         expand_build_settings setting_value, target, configuration

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -372,7 +372,8 @@ module BranchIOCLI
       end
 
       def expanded_build_setting(target, setting_name, configuration)
-        setting_value = target.resolved_build_setting(setting_name)[configuration]
+        # second arg true means if there is an xcconfig, also consult that
+        setting_value = target.resolved_build_setting(setting_name, true)[configuration]
         return if setting_value.nil?
 
         expand_build_settings setting_value, target, configuration
@@ -384,9 +385,15 @@ module BranchIOCLI
         # copy from PBXNativeTarget#resolve_build_setting anyway. Copying here
         # avoids a copy on every match.
         string = string.clone
-        while (matches = /\$\(([^(){}]*)\)|\$\{([^(){}]*)\}/.match(string, search_position))
-          original_macro = matches[1] || matches[2]
-          search_position = string.index(original_macro) - 2
+
+        # HACK: When matching against an xcconfig, as here, sometimes the macro is just returned
+        # without delimiters, e.g. TARGET_NAME or BUILT_PRODUCTS_DIR/Branch.framework. We allow
+        # these two patterns for now.
+        while (matches = %r{\$\(([^(){}]*)\)|\$\{([^(){}]*)\}|^([A-Z_]+)(/.*)?$}.match(string, search_position))
+          original_macro = matches[1] || matches[2] || matches[3]
+          delimiter_length = matches[3] ? 0 : 3 # $() or ${}
+          delimiter_offset = matches[3] ? 0 : 2 # $( or ${
+          search_position = string.index(original_macro) - delimiter_offset
 
           modifier_regexp = /^(.+):(.+)$/
           if (matches = modifier_regexp.match original_macro)
@@ -406,7 +413,7 @@ module BranchIOCLI
             expanded_macro = expanded_build_setting(target, macro_name, configuration)
           end
 
-          search_position += original_macro.length + 3 and next if expanded_macro.nil?
+          search_position += original_macro.length + delimiter_length and next if expanded_macro.nil?
 
           if modifier == "rfc1034identifier"
             # From the Apple dev portal when creating a new app ID:
@@ -417,7 +424,7 @@ module BranchIOCLI
             expanded_macro.gsub!(special_chars, '-')
           end
 
-          string.gsub!(/\$\(#{original_macro}\)|\$\{#{original_macro}\}/, expanded_macro)
+          string.gsub!(/\$\(#{original_macro}\)|\$\{#{original_macro}\}|^#{original_macro}/, expanded_macro)
           search_position += expanded_macro.length
         end
         string

--- a/spec/ios_helper_spec.rb
+++ b/spec/ios_helper_spec.rb
@@ -67,6 +67,13 @@ describe BranchIOCLI::Helper::IOSHelper do
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value/file.txt"
     end
 
+    it "resolves without an xcconfig if the xcconfig is not found" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true).and_raise(Errno::ENOENT)
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", false) { { "Release" => "$(SETTING_VALUE)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
+      expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value"
+    end
+
     it "returns nil if the setting is not present" do
       expect(target).to receive(:resolved_build_setting).with("NONEXISTENT_SETTING", true) { { "Release" => nil } }
       expect(instance.expanded_build_setting(target, "NONEXISTENT_SETTING", "Release")).to be_nil

--- a/spec/ios_helper_spec.rb
+++ b/spec/ios_helper_spec.rb
@@ -44,84 +44,96 @@ describe BranchIOCLI::Helper::IOSHelper do
   describe "#expanded_build_setting" do
     let (:target) { double "target", name: "MyTarget" }
     it "expands values delimited by $()" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE") { { "Release" => "$(SETTING_VALUE)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE") { { "Release" => "value" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "$(SETTING_VALUE)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value"
     end
 
     it "expands values delimited by ${}" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE") { { "Release" => "${SETTING_VALUE}" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE") { { "Release" => "value" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "${SETTING_VALUE}" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value"
     end
 
+    it "expands an all-caps word as a setting" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "SETTING_VALUE" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
+      expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value"
+    end
+
+    it "expands the first component of a path as a setting if all-caps" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "SETTING_VALUE/file.txt" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
+      expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value/file.txt"
+    end
+
     it "returns nil if the setting is not present" do
-      expect(target).to receive(:resolved_build_setting).with("NONEXISTENT_SETTING") { { "Release" => nil } }
+      expect(target).to receive(:resolved_build_setting).with("NONEXISTENT_SETTING", true) { { "Release" => nil } }
       expect(instance.expanded_build_setting(target, "NONEXISTENT_SETTING", "Release")).to be_nil
     end
 
     it "substitutes . for $(SRCROOT)" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_USING_SRCROOT") { { "Release" => "$(SRCROOT)/some.file" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_USING_SRCROOT", true) { { "Release" => "$(SRCROOT)/some.file" } }
       expect(instance.expanded_build_setting(target, "SETTING_USING_SRCROOT", "Release")).to eq "./some.file"
     end
 
     it "subsitutes the target name for $(TARGET_NAME)" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_USING_TARGET_NAME") { { "Release" => "$(TARGET_NAME)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_USING_TARGET_NAME", true) { { "Release" => "$(TARGET_NAME)" } }
       expect(instance.expanded_build_setting(target, "SETTING_USING_TARGET_NAME", "Release")).to eq target.name
     end
 
     it "returns the setting when no macro present" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITHOUT_MACRO") { { "Release" => "setting" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITHOUT_MACRO", true) { { "Release" => "setting" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITHOUT_MACRO", "Release")).to eq "setting"
     end
 
     it "expands multiple instances of the same macro" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE") { { "Release" => "$(SETTING_VALUE).$(SETTING_VALUE)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE") { { "Release" => "value" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "$(SETTING_VALUE).$(SETTING_VALUE)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUE", "Release")).to eq "value.value"
     end
 
     it "expands multiple macros in a setting" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES") { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => "value1" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES", true) { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1", true) { { "Release" => "value1" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2", true) { { "Release" => "value2" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUES", "Release")).to eq "value1.value2"
     end
 
     it "balances delimiters" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES") { { "Release" => "$(SETTING_VALUE1}.${SETTING_VALUE2)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES", true) { { "Release" => "$(SETTING_VALUE1}.${SETTING_VALUE2)" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUES", "Release")).to eq "$(SETTING_VALUE1}.${SETTING_VALUE2)"
     end
 
     it "expands recursively" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES") { { "Release" => "$(SETTING_VALUE1)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => "$(SETTING_VALUE2)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES", true) { { "Release" => "$(SETTING_VALUE1)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1", true) { { "Release" => "$(SETTING_VALUE2)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2", true) { { "Release" => "value2" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUES", "Release")).to eq "value2"
     end
 
     it "returns the unexpanded macro for nonexistent settings" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_BOGUS_VALUE") { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => nil } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_BOGUS_VALUE", true) { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1", true) { { "Release" => nil } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2", true) { { "Release" => "value2" } }
       expect(instance.expanded_build_setting(target, "SETTING_WITH_BOGUS_VALUE", "Release")).to eq "$(SETTING_VALUE1).value2"
     end
 
     it "recognizes :rfc1034identifier when expanding" do
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My App" } }
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME", true) { { "Release" => "My App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER", true) { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
       expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My-App"
     end
 
     it "ignores any other modifier" do
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My App" } }
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:foo)" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME", true) { { "Release" => "My App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER", true) { { "Release" => "com.example.$(PRODUCT_NAME:foo)" } }
       expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My App"
     end
 
     it "substitutes _ for special characters when :rfc1034identifier is present" do
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME") { { "Release" => "My .@*&'\\\"+%_App" } }
-      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER") { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME", true) { { "Release" => "My .@*&'\\\"+%_App" } }
+      expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER", true) { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
       expect(instance.expanded_build_setting(target, "PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My-----------App"
     end
   end


### PR DESCRIPTION
This allows all build settings to be resolved against a base xcconfig if there is one. If one is specified but does not exist (which happens, e.g., if pod install is required to generate the xcconfig), settings will be resolved without it. As always, unresolved settings are returned unmodified in substitutions, e.g. "com.example.$(PRODUCT_BUNDLE_IDENTIFIER:rfc1034identifier)" if the `PRODUCT_BUNDLE_IDENTIFIER` is not found.

Settings in Branch keys are now expanded, in case these are taken from settings, including an xcconfig.