### PR TITLE
More subproject reporting

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -157,7 +157,7 @@ EOF
         return nil unless framework
 
         if framework.file_ref.isa == "PBXFileReference"
-          project_path = config.xcodeproj_path
+          project_path = config.relative_path(config.xcodeproj_path)
           framework_path = framework.file_ref.real_path
         elsif framework.file_ref.isa == "PBXReferenceProxy" && @xcode_settings
           project_path = config.relative_path framework.file_ref.remote_ref.proxied_object.project.path
@@ -205,8 +205,8 @@ Scheme: #{config.scheme || '(none)'}
 Target: #{config.target || '(none)'}
 Configuration: #{config.configuration || '(none)'}
 SDK: #{config.sdk}
-Podfile: #{config.podfile_path || '(none)'}
-Cartfile: #{config.cartfile_path || '(none)'}
+Podfile: #{config.relative_path(config.podfile_path) || '(none)'}
+Cartfile: #{config.relative_path(config.cartfile_path) || '(none)'}
 Pod repo update: #{config.pod_repo_update.inspect}
 Clean: #{config.clean.inspect}
 EOF
@@ -329,6 +329,7 @@ EOF
       # String containing information relevant to Branch setup
       def branch_report
         infoplist_path = helper.expanded_build_setting config.target, "INFOPLIST_FILE", config.configuration
+        infoplist_path = File.expand_path infoplist_path, File.dirname(config.xcodeproj_path)
 
         report = "Branch configuration:\n"
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -155,9 +155,12 @@ EOF
       def version_from_branch_framework
         framework = config.target.frameworks_build_phase.files.find { |f| f.file_ref.path =~ /Branch.framework$/ }
         return nil unless framework
+
         if framework.file_ref.isa == "PBXFileReference"
+          project_path = config.xcodeproj_path
           framework_path = framework.file_ref.real_path
         elsif framework.file_ref.isa == "PBXReferenceProxy" && @xcode_settings
+          project_path = config.relative_path framework.file_ref.remote_ref.proxied_object.project.path
           framework_path = File.expand_path framework.file_ref.path, @xcode_settings[framework.file_ref.source_tree]
         end
         info_plist_path = File.join framework_path.to_s, "Info.plist"
@@ -168,7 +171,8 @@ EOF
         raw_info_plist = CFPropertyList::List.new file: info_plist_path
         info_plist = CFPropertyList.native_types raw_info_plist.value
         version = info_plist["CFBundleVersion"]
-        version ? "#{version} [Branch.framework/Info.plist]" : nil
+        return nil unless version
+        "#{version} [Branch.framework/Info.plist:#{project_path}]"
       end
 
       def version_from_bnc_config_m(project = @config.xcodeproj)
@@ -188,7 +192,7 @@ EOF
         matches = /BNC_SDK_VERSION\s+=\s+@"(\d+\.\d+\.\d+)"/m.match bnc_config_m
         return nil unless matches
         version = matches[1]
-        "#{version} [BNCConfig.m]"
+        "#{version} [BNCConfig.m:#{config.relative_path project.path}]"
       end
 
       def report_configuration
@@ -251,9 +255,9 @@ EOF
         header += " Deployment target: #{config.target.deployment_target}\n"
         header += " Modules #{config.modules_enabled? ? '' : 'not '}enabled\n"
         header += " Swift #{config.swift_version}\n" if config.swift_version
-        header += " Bridging header: #{config.bridging_header_path}\n" if config.bridging_header_path
-        header += " Info.plist: #{infoplist_path || '(none)'}\n"
-        header += " Entitlements file: #{entitlements_path || '(none)'}\n"
+        header += " Bridging header: #{config.relative_path(config.bridging_header_path)}\n" if config.bridging_header_path
+        header += " Info.plist: #{config.relative_path(infoplist_path) || '(none)'}\n"
+        header += " Entitlements file: #{config.relative_path(entitlements_path) || '(none)'}\n"
 
         if config.podfile_path
           begin

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -55,6 +55,21 @@ EOF
         Helper::BranchHelper
       end
 
+      def relative_path(path)
+        return nil if path.nil?
+
+        path = Pathname.new(path) unless path.kind_of? Pathname
+        return path.to_s unless path.absolute?
+
+        if workspace
+          root = Pathname.new(workspace_path).dirname
+        else
+          root = Pathname.new(xcodeproj_path).dirname
+        end
+
+        path.relative_path_from(root).to_s
+      end
+
       # 1. Look for options.xcodeproj.
       # 2. If not specified, look for projects under . (excluding anything in Pods or Carthage folder).
       # 3. If none or more than one found, prompt the user.

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -61,13 +61,15 @@ EOF
         path = Pathname.new(path) unless path.kind_of? Pathname
         return path.to_s unless path.absolute?
 
-        if workspace
-          root = Pathname.new(workspace_path).dirname
-        else
-          root = Pathname.new(xcodeproj_path).dirname
+        unless @root
+          if workspace
+            @root = Pathname.new(workspace_path).dirname
+          else
+            @root = Pathname.new(xcodeproj_path).dirname
+          end
         end
 
-        path.relative_path_from(root).to_s
+        path.relative_path_from(@root).to_s
       end
 
       # 1. Look for options.xcodeproj.
@@ -96,7 +98,7 @@ EOF
           # TODO: Allow the user to choose if xcodeproj_paths.count > 0
           begin
             @xcodeproj = Xcodeproj::Project.open path
-            @xcodeproj_path = path
+            @xcodeproj_path = File.expand_path path
             return
           rescue StandardError => e
             say e.message

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -57,12 +57,12 @@ EOF
           if options.workspace
             path = options.workspace
             @workspace = Xcodeproj::Workspace.new_from_xcworkspace options.workspace
-            @workspace_path = options.workspace
+            @workspace_path = File.expand_path options.workspace
           end
           if options.xcodeproj
             path = options.xcodeproj
             @xcodeproj = Xcodeproj::Project.open options.xcodeproj
-            @xcodeproj_path = options.xcodeproj
+            @xcodeproj_path = File.expand_path options.xcodeproj
           else
             # Pass --workspace and --xcodeproj to override this inference.
             if workspace && workspace.file_references.count > 0 && workspace.file_references.first.path =~ /\.xcodeproj$/
@@ -107,7 +107,7 @@ EOF
           begin
             if path =~ /\.xcworkspace$/
               @workspace = Xcodeproj::Workspace.new_from_xcworkspace path
-              @workspace_path = path
+              @workspace_path = File.expand_path path
 
               # Pass --workspace and --xcodeproj to override this inference.
               if workspace.file_references.count > 0 && workspace.file_references.first.path =~ /\.xcodeproj$/
@@ -118,7 +118,7 @@ EOF
               return
             elsif path =~ /\.xcodeproj$/
               @xcodeproj = Xcodeproj::Project.open path
-              @xcodeproj_path = path
+              @xcodeproj_path = File.expand_path path
               return
             else
               say "Path must end with .xcworkspace or .xcodeproj"

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -42,8 +42,8 @@ module BranchIOCLI
 <%= color('Target:', BOLD) %> #{target || '(none)'}
 <%= color('Configuration:', BOLD) %> #{configuration}
 <%= color('SDK:', BOLD) %> #{sdk}
-<%= color('Podfile:', BOLD) %> #{podfile_path || '(none)'}
-<%= color('Cartfile:', BOLD) %> #{cartfile_path || '(none)'}
+<%= color('Podfile:', BOLD) %> #{relative_path(podfile_path) || '(none)'}
+<%= color('Cartfile:', BOLD) %> #{relative_path(cartfile_path) || '(none)'}
 <%= color('Pod repo update:', BOLD) %> #{pod_repo_update.inspect}
 <%= color('Clean:', BOLD) %> #{clean.inspect}
 <%= color('Report path:', BOLD) %> #{report_path}

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -62,8 +62,8 @@ module BranchIOCLI
 <%= color('Test key:', BOLD) %> #{keys[:test] || '(none)'}
 <%= color('Domains:', BOLD) %> #{all_domains}
 <%= color('URI scheme:', BOLD) %> #{uri_scheme || '(none)'}
-<%= color('Podfile:', BOLD) %> #{podfile_path || '(none)'}
-<%= color('Cartfile:', BOLD) %> #{cartfile_path || '(none)'}
+<%= color('Podfile:', BOLD) %> #{relative_path(podfile_path) || '(none)'}
+<%= color('Cartfile:', BOLD) %> #{relative_path(cartfile_path) || '(none)'}
 <%= color('Carthage command:', BOLD) %> #{carthage_command || '(none)'}
 <%= color('Pod repo update:', BOLD) %> #{pod_repo_update.inspect}
 <%= color('Validate:', BOLD) %> #{validate.inspect}


### PR DESCRIPTION
Also report relative paths for everything but the project and workspace in the CLI configuration.

Corrected operation when the workspace or project is not in the current directory.