### PR TITLE
Bridging headers

### DIFF
--- a/lib/assets/patches/objc_import_at_end.yml
+++ b/lib/assets/patches/objc_import_at_end.yml
@@ -1,0 +1,3 @@
+regexp: '\z'
+mode: append
+text: "\n#import <Branch/Branch.h>\n"

--- a/lib/assets/patches/objc_import_include_guard.yml
+++ b/lib/assets/patches/objc_import_include_guard.yml
@@ -1,0 +1,3 @@
+regexp: '/\n\s*#ifndef\s+(\w+).*\n\s*#define\s+\1.*?\n/m'
+mode: append
+text: "\n#import <Branch/Branch.h>\n"

--- a/lib/branch_io_cli/core_ext.rb
+++ b/lib/branch_io_cli/core_ext.rb
@@ -1,1 +1,2 @@
 require "branch_io_cli/core_ext/io.rb"
+require "branch_io_cli/core_ext/regexp.rb"

--- a/lib/branch_io_cli/core_ext/regexp.rb
+++ b/lib/branch_io_cli/core_ext/regexp.rb
@@ -1,0 +1,14 @@
+class Regexp
+  def match_file(file)
+    case file
+    when File
+      contents = file.read
+    when String
+      contents = File.read file
+    else
+      raise ArgumentError, "Invalid argument type: #{file.class.name}"
+    end
+
+    match contents
+  end
+end

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -44,7 +44,9 @@ module BranchIOCLI
 
           say "Patching #{config.bridging_header_path}"
 
-          load_patch(:objc_import).apply config.bridging_header_path
+          if /^\s*(#import|#include|@import)/.match_file config.bridging_header_path
+            load_patch(:objc_import).apply config.bridging_header_path
+          end
           helper.add_change config.bridging_header_path
         end
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -45,7 +45,14 @@ module BranchIOCLI
           say "Patching #{config.bridging_header_path}"
 
           if /^\s*(#import|#include|@import)/.match_file config.bridging_header_path
+            # Add among other imports
             load_patch(:objc_import).apply config.bridging_header_path
+          elsif /\n\s*#ifndef\s+(\w+).*\n\s*#define\s+\1.*?\n/m.match_file config.bridging_header_path
+            # Has an include guard. Add inside.
+            load_patch(:objc_import_include_guard).apply config.bridging_header_path
+          else
+            # No imports, no include guard. Add at the end.
+            load_patch(:objc_import_at_end).apply config.bridging_header_path
           end
           helper.add_change config.bridging_header_path
         end


### PR DESCRIPTION
Additional patches for bridging headers. The `objc_import` patch is used in app delegates, where there must always be a `#import` or `@import` of at least UIKit in order to build. The Branch import is added just above that.

It's not hard to find a project with an unused bridging header. If no import is found in the bridging header, the CLI looks for an include guard:

```Obj-C
#ifndef SOMETHING
#define SOMETHING
```

with some allowance for spacing. If this is found, the import goes just after the `#define`. If no import and no include guard is present, the Branch import is inserted at the end of the file.