### PR TITLE
Validation fixes

### DIFF
--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -157,6 +157,7 @@ EOF
       def open_podfile(path = @podfile_path)
         @podfile = Pod::Podfile.from_file path
         @podfile_path = path
+        @sdk_integration_mode = :cocoapods
         true
       rescue RuntimeError => e
         say e.message
@@ -176,6 +177,7 @@ EOF
           true
         elsif filename == "Cartfile"
           @cartfile_path = buildfile_path
+          @sdk_integration_mode = :carthage
           true
         else
           false

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -169,7 +169,7 @@ EOF
 
         if valid
           valid = File.exist? buildfile_path
-          say "#{buildfile_path} not found." unless valid
+          say "#{buildfile_path} not found." and return false unless valid
         end
 
         if filename == "Podfile" && open_podfile(buildfile_path)

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -4,6 +4,7 @@ module BranchIOCLI
       APP_LINK_REGEXP = /\.app\.link$|\.test-app\.link$/
       SDK_OPTIONS =
         {
+          "Specify the location of a Podfile or Cartfile" => :specify,
           "Set this project up to use CocoaPods and add the Branch SDK." => :cocoapods,
           "Set this project up to use Carthage and add the Branch SDK." => :carthage,
           "Add Branch.framework directly to the project's dependencies." => :direct,
@@ -183,6 +184,20 @@ module BranchIOCLI
         scheme.sub %r{://$}, ""
       end
 
+      def prompt_for_podfile_or_cartfile
+        loop do
+          path = ask("Please enter the location of your Podfile or Cartfile: ").trim
+          case path
+          when %r{/?Podfile$}
+            return if validate_buildfile_at_path path, "Podfile"
+          when %r{/?Cartfile$}
+            return if validate_buildfile_at_path path, "Cartfile"
+          else
+            say "Path must end in Podfile or Cartfile."
+          end
+        end
+      end
+
       def validate_sdk_addition(options)
         return if !options.add_sdk || sdk_integration_mode
 
@@ -202,6 +217,8 @@ module BranchIOCLI
         @sdk_integration_mode = SDK_OPTIONS[selected]
 
         case sdk_integration_mode
+        when :specify
+          prompt_for_podfile_or_cartfile
         when :cocoapods
           @podfile_path = File.expand_path "../Podfile", xcodeproj_path
         when :carthage


### PR DESCRIPTION
If a Podfile or Cartfile is not found, the user is prompted to set the project up or download the framework. Now those options include specifying the location of the Podfile or Cartfile, in case it was just not inferred correctly.

Corrected Podfile/Cartfile validation in case the specified file doesn't exist.