### PR TITLE
Improve determination of AppDelegate paths

### DIFF
--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -198,6 +198,22 @@ EOF
         podfile && !uses_frameworks?
       end
 
+      def app_delegate_swift_path
+        return nil unless swift_version && swift_version.to_f >= 3.0
+
+        app_delegate = target.source_build_phase.files.find { |f| f.file_ref.path =~ /AppDelegate\.swift$/ }
+        return nil if app_delegate.nil?
+
+        app_delegate.file_ref.real_path.to_s
+      end
+
+      def app_delegate_objc_path
+        app_delegate = target.source_build_phase.files.find { |f| f.file_ref.path =~ /AppDelegate\.m$/ }
+        return nil if app_delegate.nil?
+
+        app_delegate.file_ref.real_path.to_s
+      end
+
       # TODO: How many of these can vary by configuration?
 
       def modules_enabled?

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -58,12 +58,10 @@ module BranchIOCLI
         end
 
         def patch_app_delegate_swift(project)
-          return false unless config.swift_version
+          return false unless config.patch_source
+          app_delegate_swift_path = config.app_delegate_swift_path
 
-          app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
-          return false if app_delegate_swift.nil?
-
-          app_delegate_swift_path = app_delegate_swift.real_path.to_s
+          return false unless app_delegate_swift_path
 
           app_delegate = File.read app_delegate_swift_path
 
@@ -87,10 +85,10 @@ module BranchIOCLI
         end
 
         def patch_app_delegate_objc(project)
-          app_delegate_objc = project.files.find { |f| f.path =~ /AppDelegate.m$/ }
-          return false if app_delegate_objc.nil?
+          return false unless config.patch_source
+          app_delegate_objc_path = config.app_delegate_objc_path
 
-          app_delegate_objc_path = app_delegate_objc.real_path.to_s
+          return false unless app_delegate_objc_path
 
           app_delegate = File.read app_delegate_objc_path
           return false if app_delegate =~ %r{^\s+#import\s+<Branch/Branch.h>|^\s+@import\s+Branch\s*;}


### PR DESCRIPTION
This limits the search for an AppDelegate to the source files for the given target. This makes it possible to use the CLI to set up multiple app targets in a project correctly, and prevents source patching when only setting up an extension.

Also Swift patching is limited to Swift >= 3.0 now. The CLI patches work with both Swift 3 & 4.