### PR TITLE
Report imports

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -94,6 +94,10 @@ EOF
         say "Report generated in #{config.report_path}"
       end
 
+      def report_helper
+        Helper::ReportHelper
+      end
+
       def base_xcodebuild_cmd
         cmd = "xcodebuild"
         if config.workspace_path
@@ -375,6 +379,8 @@ EOF
             report += " (Failed to get Universal Link domains from entitlements file: #{e.message})\n"
           end
         end
+
+        report += report_helper.report_imports
 
         report
       end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -251,7 +251,7 @@ EOF
       end
 
       def branch_imports_from_file(path)
-        File.readlines(path).grep(/import.*Branch/).map &:chomp
+        File.readlines(path).grep(/(import|include).*Branch/).map &:chomp
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -250,8 +250,15 @@ EOF
         @branch_imports
       end
 
+      # Detect anything that appears to be an attempt to import the Branch SDK,
+      # even if it might be wrong.
       def branch_imports_from_file(path)
-        File.readlines(path).grep(/(import|include).*Branch/).map &:chomp
+        imports = []
+        File.readlines(path).each_with_index do |line, line_no|
+          next unless line =~ /(include|import).*branch/i
+          imports << "#{line_no}: #{line.chomp}"
+        end
+        imports
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -241,6 +241,18 @@ EOF
         @swift_version = target.resolved_build_setting("SWIFT_VERSION")["Release"]
         @swift_version
       end
+
+      def branch_imports
+        return @branch_imports if @branch_imports
+
+        source_files = [app_delegate_swift_path, app_delegate_objc_path, bridging_header_path]
+        @branch_imports = source_files.compact.map { |f| { f => branch_imports_from_file(f) } }.inject({}, :merge)
+        @branch_imports
+      end
+
+      def branch_imports_from_file(path)
+        File.readlines(path).grep(/import.*Branch/).map &:chomp
+      end
     end
   end
 end

--- a/lib/branch_io_cli/helper.rb
+++ b/lib/branch_io_cli/helper.rb
@@ -1,2 +1,3 @@
 require "branch_io_cli/helper/branch_helper"
 require "branch_io_cli/helper/patch_helper"
+require "branch_io_cli/helper/report_helper"

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -1,0 +1,23 @@
+require "branch_io_cli/configuration/configuration"
+
+module BranchIOCLI
+  module Helper
+    class ReportHelper
+      class << self
+        def report_imports
+          report = "Branch imports:\n"
+          config.branch_imports.each_key do |path|
+            report += " #{File.basename path}:\n"
+            report += "  #{config.branch_imports[path].join("\n  ")}"
+            report += "\n"
+          end
+          report
+        end
+
+        def config
+          Configuration::Configuration.current
+        end
+      end
+    end
+  end
+end

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -7,7 +7,7 @@ module BranchIOCLI
         def report_imports
           report = "Branch imports:\n"
           config.branch_imports.each_key do |path|
-            report += " #{File.basename path}:\n"
+            report += " #{config.relative_path path}:\n"
             report += "  #{config.branch_imports[path].join("\n  ")}"
             report += "\n"
           end


### PR DESCRIPTION
The report command now includes all Branch imports from an app delegate or bridging header. This is broad enough to detect commented lines, attempts to `#include` the header and wrapper SDKs like React Native.