### PR TITLE
Requires and shellwords

### DIFF
--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 module BranchIOCLI
   module Command
     class ReportCommand < Command
@@ -51,14 +53,15 @@ EOF
           if config.workspace_path
             config.workspace.file_references.map(&:path).each do |project_path|
               path = File.join File.dirname(config.workspace_path), project_path
-              report.log_command "xcodebuild -list -project #{path}"
+              report.log_command "xcodebuild -list -project #{Shellwords.escape path}"
             end
           end
 
           base_cmd = report_helper.base_xcodebuild_cmd
           # Add more options for the rest of the commands
-          base_cmd = "#{base_cmd} -scheme #{config.scheme}"
-          base_cmd = "#{base_cmd} -configuration #{config.configuration} -sdk #{config.sdk}"
+          base_cmd += " -scheme #{Shellwords.escape config.scheme}"
+          base_cmd += " -configuration #{Shellwords.escape config.configuration}"
+          base_cmd += " -sdk #{Shellwords.escape config.sdk}"
 
           # xcodebuild -showBuildSettings
           xcode_settings.log_xcodebuild_showbuildsettings report

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -1,9 +1,3 @@
-require "cocoapods-core"
-require "branch_io_cli/helper/methods"
-require "open3"
-require "plist"
-require "xcodeproj"
-
 module BranchIOCLI
   module Command
     class ReportCommand < Command

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -1,3 +1,5 @@
+require "xcodeproj"
+
 module BranchIOCLI
   module Configuration
     class ReportConfiguration < Configuration

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -1,4 +1,5 @@
 require "open3"
+require "shellwords"
 
 module BranchIOCLI
   module Configuration
@@ -30,12 +31,14 @@ module BranchIOCLI
       def xcodebuild_cmd
         cmd = "xcodebuild"
         if config.workspace_path
-          cmd = "#{cmd} -workspace #{config.workspace_path}"
+          cmd = "#{cmd} -workspace #{Shellwords.escape config.workspace_path}"
         else
-          cmd = "#{cmd} -project #{config.xcodeproj_path}"
+          cmd = "#{cmd} -project #{Shellwords.escape config.xcodeproj_path}"
         end
-        cmd += " -scheme #{config.scheme}"
-        cmd += " -configuration #{config.configuration} -sdk #{config.sdk} -showBuildSettings"
+        cmd += " -scheme #{Shellwords.escape config.scheme}"
+        cmd += " -configuration #{Shellwords.escape config.configuration}"
+        cmd += " -sdk #{Shellwords.escape config.sdk}"
+        cmd += " -showBuildSettings"
         cmd
       end
 

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -1,3 +1,5 @@
+require "open3"
+
 module BranchIOCLI
   module Configuration
     class XcodeSettings

--- a/lib/branch_io_cli/helper/branch_helper.rb
+++ b/lib/branch_io_cli/helper/branch_helper.rb
@@ -1,7 +1,6 @@
 require "branch_io_cli/helper/android_helper"
 require "branch_io_cli/helper/ios_helper"
 require "net/http"
-require "pattern_patch"
 require "set"
 
 module BranchIOCLI

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -1,4 +1,5 @@
 require "plist"
+require "shellwords"
 require "branch_io_cli/configuration/configuration"
 
 module BranchIOCLI
@@ -30,9 +31,9 @@ module BranchIOCLI
         def base_xcodebuild_cmd
           cmd = "xcodebuild"
           if config.workspace_path
-            cmd = "#{cmd} -workspace #{config.workspace_path}"
+            cmd = "#{cmd} -workspace #{Shellwords.escape config.workspace_path}"
           else
-            cmd = "#{cmd} -project #{config.xcodeproj_path}"
+            cmd = "#{cmd} -project #{Shellwords.escape config.xcodeproj_path}"
           end
           cmd
         end

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -1,3 +1,4 @@
+require "plist"
 require "branch_io_cli/configuration/configuration"
 
 module BranchIOCLI


### PR DESCRIPTION
Removed and moved a number of requires.

Use shellwords whenever building Xcode commands.