### PR TITLE
User scheme support

### DIFF
--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -1,3 +1,4 @@
+require "plist"
 require "xcodeproj"
 
 module Xcodeproj
@@ -12,10 +13,21 @@ module Xcodeproj
     # @return [Array]
     #
     def self.schemes(project_path)
-      schemes = Dir[File.join(project_path, 'xcshareddata', 'xcschemes', '*.xcscheme'),
-                    File.join(project_path, 'xcuserdata', "#{ENV['USER']}.xcuserdatad", 'xcschemes', '*.xcscheme')].map do |scheme|
-        File.basename(scheme, '.xcscheme')
+      base_dirs = [File.join(project_path, 'xcshareddata', 'xcschemes'),
+                   File.join(project_path, 'xcuserdata', "#{ENV['USER']}.xcuserdatad", 'xcschemes')]
+
+      # Take any .xcscheme file from base_dirs
+      schemes = base_dirs.inject([]) { |memo, dir| memo + Dir[File.join dir, '*.xcscheme'] }
+                         .map { |f| File.basename(f, '.xcscheme') }
+
+      # Include any scheme defined in the xcschememanagement.plist, if it exists.
+      base_dirs.map { |d| File.join d, 'xcschememanagement.plist' }
+               .select { |f| File.exist? f }.each do |plist_path|
+        plist = File.open(plist_path) { |f| ::Plist.parse_xml f }
+        scheme_user_state = plist["SchemeUserState"]
+        schemes += scheme_user_state.keys.map { |k| File.basename k, '.xcscheme' }
       end
+
       schemes.uniq!
       schemes << File.basename(project_path, '.xcodeproj') if schemes.empty?
       schemes

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -1,5 +1,28 @@
 require "xcodeproj"
 
+module Xcodeproj
+  class Project
+    # Local override to allow for user schemes.
+    #
+    # Get list of shared and user schemes in project
+    #
+    # @param [String] path
+    #         project path
+    #
+    # @return [Array]
+    #
+    def self.schemes(project_path)
+      schemes = Dir[File.join(project_path, 'xcshareddata', 'xcschemes', '*.xcscheme'),
+                    File.join(project_path, 'xcuserdata', "#{ENV['USER']}.xcuserdatad", 'xcschemes', '*.xcscheme')].map do |scheme|
+        File.basename(scheme, '.xcscheme')
+      end
+      schemes.uniq!
+      schemes << File.basename(project_path, '.xcodeproj') if schemes.empty?
+      schemes
+    end
+  end
+end
+
 module BranchIOCLI
   module Configuration
     class ReportConfiguration < Configuration


### PR DESCRIPTION
This change allows the CLI to recognize schemes defined under an xcuserdatad or in an xcschememanagement.plist.