### PR TITLE
Scheme per target

### DIFF
--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -31,7 +31,7 @@ module Xcodeproj
       schemes.uniq!
       if schemes.empty?
         # Open the project, get all targets. Add one scheme per target.
-        project = Project.open project_path
+        project = self.open project_path
         schemes += project.targets.reject(&:test_target_type?).map(&:name)
       end
       schemes
@@ -252,8 +252,7 @@ EOF
 
         unless scheme_path
           # Look for a local scheme
-          user = xcode_settings["USER"] if xcode_settings
-          user ||= ENV["USER"] || ENV["LOGNAME"]
+          user = ENV["USER"]
           xcuserdata_path = File.join project_path, "xcuserdata", "#{user}.xcuserdatad", "xcschemes", "#{@scheme}.xcscheme"
           scheme_path = xcuserdata_path if File.exist?(xcuserdata_path)
         end

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -29,7 +29,11 @@ module Xcodeproj
       end
 
       schemes.uniq!
-      schemes << File.basename(project_path, '.xcodeproj') if schemes.empty?
+      if schemes.empty?
+        # Open the project, get all targets. Add one scheme per target.
+        project = Project.open project_path
+        schemes += project.targets.reject(&:test_target_type?).map(&:name)
+      end
       schemes
     end
   end

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -7,7 +7,7 @@ module BranchIOCLI
       class << self
         def settings
           return @settings if @settings
-          @settings = XcodeSettings.new
+          @settings = self.new
           @settings
         end
       end
@@ -30,12 +30,8 @@ module BranchIOCLI
 
       def xcodebuild_cmd
         cmd = "xcodebuild"
-        if config.workspace_path
-          cmd = "#{cmd} -workspace #{Shellwords.escape config.workspace_path}"
-        else
-          cmd = "#{cmd} -project #{Shellwords.escape config.xcodeproj_path}"
-        end
-        cmd += " -scheme #{Shellwords.escape config.scheme}"
+        cmd = "#{cmd} -project #{Shellwords.escape config.xcodeproj_path}"
+        cmd += " -target #{Shellwords.escape config.target.name}"
         cmd += " -configuration #{Shellwords.escape config.configuration}"
         cmd += " -sdk #{Shellwords.escape config.sdk}"
         cmd += " -showBuildSettings"

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -345,11 +345,13 @@ module BranchIOCLI
         if target_name
           target = project.targets.find { |t| t.name == target_name }
           raise "Target #{target} not found" if target.nil?
+        elsif config.respond_to?(:scheme) && project.targets.map(&:name).include?(config.scheme)
+          # Return a target with the same name as the scheme, if there is one.
+          target = project.targets.find { |t| t.name == config.scheme }
         else
           # find the first application target
-          targets = project.targets.select { |t| !t.extension_target_type? && !t.test_target_type? }
-          target = targets.find { |t| t.name == File.basename(project.path).sub(/\.xcodeproj$/, "") } || targets.first
-          raise "No application target found" if target.nil?
+          target = targets.find { |t| t.name == File.basename(project.path, '.xcodeproj') } ||
+                   project.targets.select { |t| !t.extension_target_type? && !t.test_target_type? }.first
         end
         target
       end


### PR DESCRIPTION
Further improvement to scheme and target selection.

Also report Xcode build settings only for the specific target, since they're only used in per-target reporting.