### PR TITLE
User-defined setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ that the relevant commands are available in your `PATH`.
 |--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
 |-D, --domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
 |-U, --uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
-|-S, --setting [BRANCH_KEY_SETTING]|Use a custom build setting for the Branch key (default: Use Info.plist)|
+|-s, --setting [BRANCH_KEY_SETTING]|Use a custom build setting for the Branch key (default: Use Info.plist)|
+|--test-configurations|List of configurations that use the test key with a custom build setting (default: Debug configurations)|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ report with additional diagnostic information suitable for opening a support tic
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|
-|--out ./report.txt|Path to use for the generated report (default: ./report.txt)|
+|-o, --out ./report.txt|Path to use for the generated report (default: ./report.txt)|
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ that the relevant commands are available in your `PATH`.
 |--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|
 |-D, --domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|
 |-U, --uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|
+|-S, --setting [BRANCH_KEY_SETTING]|Use a custom build setting for the Branch key (default: Use Info.plist)|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -12,7 +12,8 @@ _branch_io_complete()
     global_opts="-h --help -t --trace -v --version"
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -S"
+    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
+    setup_opts="$setup_opts --test-configurations"
     # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
     setup_opts="$setup_opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -13,7 +13,7 @@ _branch_io_complete()
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
     setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
-    setup_opts="$setup_opts --test-configurations"
+    setup_opts="$setup_opts --test-configurations --no-test-configurations"
     # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
     setup_opts="$setup_opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -12,7 +12,7 @@ _branch_io_complete()
     global_opts="-h --help -t --trace -v --version"
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command"
+    setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -S"
     # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
     setup_opts="$setup_opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.zsh
+++ b/lib/assets/completions/completion.zsh
@@ -5,7 +5,8 @@ _branch_io_complete() {
   word="$1"
   opts="-h --help -t --trace -v --version"
   opts="$opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -S"
+  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
+  opts="$opts --test-configurations"
   # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
   opts="$opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.zsh
+++ b/lib/assets/completions/completion.zsh
@@ -6,7 +6,7 @@ _branch_io_complete() {
   opts="-h --help -t --trace -v --version"
   opts="$opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
   opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
-  opts="$opts --test-configurations"
+  opts="$opts --test-configurations --no-test-configurations"
   # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
   opts="$opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.zsh
+++ b/lib/assets/completions/completion.zsh
@@ -5,7 +5,7 @@ _branch_io_complete() {
   word="$1"
   opts="-h --help -t --trace -v --version"
   opts="$opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
-  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command"
+  opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -S"
   # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
   opts="$opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -78,7 +78,7 @@ EOF
         c.option "-D", "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
         c.option "-U", "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
         c.option "-s", "--setting [BRANCH_KEY_SETTING]", String, "Use a custom build setting for the Branch key (default: Use Info.plist)"
-        c.option "--test-configurations config1,config2", Array, "List of configurations that use the test key with a custom build setting (default: Debug configurations)"
+        c.option "--[no-]test-configurations [config1,config2]", Array, "List of configurations that use the test key with a custom build setting (default: Debug configurations)"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -77,7 +77,8 @@ EOF
         c.option "--app-link-subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
         c.option "-D", "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
         c.option "-U", "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
-        c.option "-S", "--setting [BRANCH_KEY_SETTING]", String, "Use a custom build setting for the Branch key (default: Use Info.plist)"
+        c.option "-s", "--setting [BRANCH_KEY_SETTING]", String, "Use a custom build setting for the Branch key (default: Use Info.plist)"
+        c.option "--test-configurations config1,config2", Array, "List of configurations that use the test key with a custom build setting (default: Debug configurations)"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -171,7 +171,7 @@ EOF
         c.option "--[no-]clean", "Clean before attempting to build (default: yes)"
         c.option "-H", "--[no-]header-only", "Write a report header to standard output and exit"
         c.option "--[no-]pod-repo-update", "Update the local podspec repo before installing (default: yes)"
-        c.option "--out ./report.txt", String, "Report output path (default: ./report.txt)"
+        c.option "-o", "--out ./report.txt", String, "Report output path (default: ./report.txt)"
 
         c.action do |args, options|
           options.default(

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -77,6 +77,7 @@ EOF
         c.option "--app-link-subdomain myapp", String, "Branch app.link subdomain, e.g. myapp for myapp.app.link"
         c.option "-D", "--domains example.com,www.example.com", Array, "Comma-separated list of custom domain(s) or non-Branch domain(s)"
         c.option "-U", "--uri-scheme myurischeme[://]", String, "Custom URI scheme used in the Branch Dashboard for this app"
+        c.option "-S", "--setting [BRANCH_KEY_SETTING]", String, "Use a custom build setting for the Branch key (default: Use Info.plist)"
 
         c.option "--xcodeproj MyProject.xcodeproj", String, "Path to an Xcode project to update"
         c.option "--target MyAppTarget", String, "Name of a target to modify in the Xcode project"

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -18,51 +18,58 @@ module BranchIOCLI
           exit 0
         end
 
-        File.open config.report_path, "w" do |report|
-          report.write "Branch.io Xcode build report v #{VERSION} #{DateTime.now}\n\n"
-          report.write "#{config.report_configuration}\n"
-          report.write "#{report_helper.report_header}\n"
+        if config.report_path == "stdout"
+          write_report STDOUT
+        else
+          File.open(config.report_path, "w") { |f| write_report f }
+          say "Report generated in #{config.report_path}"
+        end
+      end
 
-          report_helper.pod_install_if_required report
+      def write_report(report)
+        report.write "Branch.io Xcode build report v #{VERSION} #{DateTime.now}\n\n"
+        report.write "#{config.report_configuration}\n"
+        report.write "#{report_helper.report_header}\n"
 
-          # run xcodebuild -list
-          report.log_command "#{report_helper.base_xcodebuild_cmd} -list"
+        report_helper.pod_install_if_required report
 
-          # If using a workspace, -list all the projects as well
-          if config.workspace_path
-            config.workspace.file_references.map(&:path).each do |project_path|
-              path = File.join File.dirname(config.workspace_path), project_path
-              report.log_command "xcodebuild -list -project #{Shellwords.escape path}"
-            end
-          end
+        # run xcodebuild -list
+        report.log_command "#{report_helper.base_xcodebuild_cmd} -list"
 
-          base_cmd = report_helper.base_xcodebuild_cmd
-          # Add more options for the rest of the commands
-          base_cmd += " -scheme #{Shellwords.escape config.scheme}"
-          base_cmd += " -configuration #{Shellwords.escape config.configuration}"
-          base_cmd += " -sdk #{Shellwords.escape config.sdk}"
-
-          # xcodebuild -showBuildSettings
-          xcode_settings.log_xcodebuild_showbuildsettings report
-
-          if config.clean
-            say "Cleaning"
-            if report.log_command("#{base_cmd} clean").success?
-              say "Done ✅"
-            else
-              say "Clean failed."
-            end
-          end
-
-          say "Building"
-          if report.log_command("#{base_cmd} -verbose").success?
-            say "Done ✅"
-          else
-            say "Build failed."
+        # If using a workspace, -list all the projects as well
+        if config.workspace_path
+          config.workspace.file_references.map(&:path).each do |project_path|
+            path = File.join File.dirname(config.workspace_path), project_path
+            report.log_command "xcodebuild -list -project #{Shellwords.escape path}"
           end
         end
 
-        say "Report generated in #{config.report_path}"
+        # xcodebuild -showBuildSettings
+        xcode_settings.log_xcodebuild_showbuildsettings report
+
+        base_cmd = report_helper.base_xcodebuild_cmd
+        # Add more options for the rest of the commands
+        base_cmd += " -scheme #{Shellwords.escape config.scheme}"
+        base_cmd += " -configuration #{Shellwords.escape config.configuration}"
+        base_cmd += " -sdk #{Shellwords.escape config.sdk}"
+
+        if config.clean
+          say "Cleaning"
+          if report.log_command("#{base_cmd} clean").success?
+            say "Done ✅"
+          else
+            say "Clean failed."
+          end
+        end
+
+        say "Building"
+        if report.log_command("#{base_cmd} -verbose").success?
+          say "Done ✅"
+        else
+          say "Build failed."
+        end
+
+        say "Done ✅"
       end
 
       def report_helper

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -50,7 +50,7 @@ module BranchIOCLI
         base_cmd = report_helper.base_xcodebuild_cmd
         # Add more options for the rest of the commands
         base_cmd += " -scheme #{Shellwords.escape config.scheme}"
-        base_cmd += " -configuration #{Shellwords.escape config.configuration}"
+        base_cmd += " -configuration #{Shellwords.escape(config.configuration || config.configurations_from_scheme.first)}"
         base_cmd += " -sdk #{Shellwords.escape config.sdk}"
 
         if config.clean

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -68,8 +68,6 @@ module BranchIOCLI
         else
           say "Build failed."
         end
-
-        say "Done ✅"
       end
 
       def report_helper

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -35,9 +35,11 @@ module BranchIOCLI
         rescue RuntimeError
           helper.verify_cocoapods
           say "Installing pods to resolve current build settings"
-          # We haven't modified anything yet. Don't use --repo-update at this stage.
-          # This is unlikely to fail.
-          sh "pod install"
+          Dir.chdir(File.dirname(config.podfile_path)) do
+            # We haven't modified anything yet. Don't use --repo-update at this stage.
+            # This is unlikely to fail.
+            sh "pod install"
+          end
         end
 
         helper.add_custom_build_setting if config.setting

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -33,8 +33,6 @@ module BranchIOCLI
         begin
           config.xcodeproj.build_configurations.first.debug?
         rescue RuntimeError
-          # Work around a potential crash for now. The PBXBuildConfiguration#debug?
-          # method may raise in this case.
           helper.verify_cocoapods
           say "Installing pods to resolve current build settings"
           # We haven't modified anything yet. Don't use --repo-update at this stage.

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -30,8 +30,9 @@ module BranchIOCLI
           say "Universal Link configuration passed validation. ✅"
         end
 
-        if @keys.count > 1 && helper.has_multiple_info_plists? &&
-           !File.exist?(File.join(File.dirname(config.podfile_path), 'Pods'))
+        begin
+          config.xcodeproj.build_configurations.first.debug?
+        rescue RuntimeError
           # Work around a potential crash for now. The PBXBuildConfiguration#debug?
           # method may raise in this case.
           helper.verify_cocoapods
@@ -41,7 +42,8 @@ module BranchIOCLI
           sh "pod install"
         end
 
-        # the following calls can all raise IOError
+        helper.add_custom_build_setting if config.setting
+
         helper.add_keys_to_info_plist @keys
         helper.add_branch_universal_link_domains_to_info_plist @domains if is_app_target
         helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -268,11 +268,11 @@ EOF
         setting == "YES"
       end
 
-      def bridging_header_path
+      def bridging_header_path(configuration = "Release")
         return @bridging_header_path if @bridging_header_path
 
         return nil unless target
-        path = helper.expanded_build_setting target, "SWIFT_OBJC_BRIDGING_HEADER", "Release"
+        path = helper.expanded_build_setting target, "SWIFT_OBJC_BRIDGING_HEADER", configuration
         return nil unless path
 
         @bridging_header_path = File.expand_path path, File.dirname(xcodeproj_path)

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -105,7 +105,7 @@ EOF
 <%= color('Xcode project:', BOLD) %> #{xcodeproj_path || '(none)'}
 <%= color('Scheme:', BOLD) %> #{scheme || '(none)'}
 <%= color('Target:', BOLD) %> #{target || '(none)'}
-<%= color('Configuration:', BOLD) %> #{configuration}
+<%= color('Configuration:', BOLD) %> #{configuration || '(none)'}
 <%= color('SDK:', BOLD) %> #{sdk}
 <%= color('Podfile:', BOLD) %> #{relative_path(podfile_path) || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{relative_path(cartfile_path) || '(none)'}
@@ -265,11 +265,13 @@ EOF
       end
 
       def validate_configuration(options)
+        return unless options.configuration
+
         all_configs = xcodeproj.build_configurations.map(&:name)
 
-        if options.configuration && all_configs.include?(options.configuration)
+        if all_configs.include?(options.configuration)
           @configuration = options.configuration
-        elsif options.configuration
+        else
           say "Configuration #{options.configuration} not found."
           @configuration = choose do |menu|
             menu.header = "Configurations from project"
@@ -277,14 +279,11 @@ EOF
             menu.prompt = "Please choose one of the above. "
           end
         end
+      end
 
-        return if @configuration
-
-        @configuration = "Debug" # Usual default for the launch action
-
-        return unless xcscheme
-
-        @configuration = xcscheme.launch_action.build_configuration
+      def configurations_from_scheme
+        return ["Debug", "Release"] unless xcscheme
+        %i[test launch profile archive analyze].map { |pfx| xcscheme.send("#{pfx}_action").build_configuration }.uniq
       end
 
       def branch_version
@@ -378,7 +377,7 @@ EOF
         "#{version} [BNCConfig.m:#{relative_path project.path}]"
       end
 
-      def branch_key_setting_from_info_plist
+      def branch_key_setting_from_info_plist(configuration = config.configuration || "Release")
         return @branch_key_setting_from_info_plist if @branch_key_setting_from_info_plist
 
         infoplist_path = helper.expanded_build_setting target, "INFOPLIST_FILE", configuration

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -382,6 +382,7 @@ EOF
         return @branch_key_setting_from_info_plist if @branch_key_setting_from_info_plist
 
         infoplist_path = helper.expanded_build_setting target, "INFOPLIST_FILE", configuration
+        infoplist_path = File.expand_path infoplist_path, File.dirname(xcodeproj_path)
         info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
         branch_key = info_plist["branch_key"]
         regexp = /^\$\((\w+)\)$|^\$\{(\w+)\}$/

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -377,6 +377,18 @@ EOF
         version = matches[1]
         "#{version} [BNCConfig.m:#{relative_path project.path}]"
       end
+
+      def branch_key_setting_from_info_plist
+        return @branch_key_setting_from_info_plist if @branch_key_setting_from_info_plist
+
+        infoplist_path = helper.expanded_build_setting target, "INFOPLIST_FILE", configuration
+        info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
+        branch_key = info_plist["branch_key"]
+        regexp = /^\$\((\w+)\)$|^\$\{(\w+)\}$/
+        return nil unless branch_key.kind_of?(String) && (matches = regexp.match branch_key)
+        @branch_key_setting_from_info_plist = matches[1] || matches[2]
+        @branch_key_setting_from_info_plist
+      end
     end
   end
 end

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -377,10 +377,10 @@ EOF
         "#{version} [BNCConfig.m:#{relative_path project.path}]"
       end
 
-      def branch_key_setting_from_info_plist(configuration = config.configuration || "Release")
+      def branch_key_setting_from_info_plist(config = configuration || "Release")
         return @branch_key_setting_from_info_plist if @branch_key_setting_from_info_plist
 
-        infoplist_path = helper.expanded_build_setting target, "INFOPLIST_FILE", configuration
+        infoplist_path = helper.expanded_build_setting target, "INFOPLIST_FILE", config
         infoplist_path = File.expand_path infoplist_path, File.dirname(xcodeproj_path)
         info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
         branch_key = info_plist["branch_key"]

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -289,6 +289,7 @@ module BranchIOCLI
           @test_configurations = test_configs and return if invalid_configurations.empty?
 
           say "The following test configurations are invalid: #{invalid_configurations}."
+          say "Available configurations: #{all_configurations}"
           test_configs = ask "Please enter a comma-separated list of configurations to use the Branch test key: ", Array
         end
       end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -20,6 +20,7 @@ module BranchIOCLI
       attr_reader :force
       attr_reader :patch_source
       attr_reader :commit
+      attr_reader :setting
 
       def validate_options
         @validate = options.validate
@@ -39,6 +40,7 @@ module BranchIOCLI
         validate_keys_from_setup_options options
         validate_all_domains options, !target.extension_target_type?
         validate_uri_scheme options
+        validate_setting options
 
         # If neither --podfile nor --cartfile is present, arbitrarily look for a Podfile
         # first.
@@ -63,6 +65,15 @@ module BranchIOCLI
 <%= color('Test key:', BOLD) %> #{keys[:test] || '(none)'}
 <%= color('Domains:', BOLD) %> #{all_domains}
 <%= color('URI scheme:', BOLD) %> #{uri_scheme || '(none)'}
+        EOF
+
+        if setting
+          message += <<-EOF
+<%= color('Branch key setting:', BOLD) %> #{setting}
+          EOF
+        end
+
+        message += <<-EOF
 <%= color('Podfile:', BOLD) %> #{relative_path(podfile_path) || '(none)'}
 <%= color('Cartfile:', BOLD) %> #{relative_path(cartfile_path) || '(none)'}
 <%= color('Carthage command:', BOLD) %> #{carthage_command || '(none)'}
@@ -239,6 +250,18 @@ module BranchIOCLI
         when :carthage
           @cartfile_path = File.expand_path "../Cartfile", xcodeproj_path
           @carthage_command = options.carthage_command
+        end
+      end
+
+      def validate_setting(options)
+        setting = options.setting
+        return if setting.nil?
+
+        @setting = "BRANCH_KEY" and return if setting.empty?
+
+        loop do
+          return if setting =~ /A-Z0-9_/
+          setting = "Invalid build setting. Please enter an all-caps identifier (may include digits and underscores): "
         end
       end
     end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -260,7 +260,7 @@ module BranchIOCLI
         @setting = "BRANCH_KEY" and return if setting == true
 
         loop do
-          return if setting =~ /A-Z0-9_/
+          return if setting =~ /^[A-Z0-9_]+$/
           setting = "Invalid build setting. Please enter an all-caps identifier (may include digits and underscores): "
         end
       end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -257,7 +257,7 @@ module BranchIOCLI
         setting = options.setting
         return if setting.nil?
 
-        @setting = "BRANCH_KEY" and return if setting.empty?
+        @setting = "BRANCH_KEY" and return if setting == true
 
         loop do
           return if setting =~ /A-Z0-9_/

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -264,7 +264,7 @@ module BranchIOCLI
             @setting = setting
             return
           end
-          setting = "Invalid build setting. Please enter an all-caps identifier (may include digits and underscores): "
+          setting = ask "Invalid build setting. Please enter an all-caps identifier (may include digits and underscores): "
         end
       end
     end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -260,7 +260,10 @@ module BranchIOCLI
         @setting = "BRANCH_KEY" and return if setting == true
 
         loop do
-          return if setting =~ /^[A-Z0-9_]+$/
+          if setting =~ /^[A-Z0-9_]+$/
+            @setting = setting
+            return
+          end
           setting = "Invalid build setting. Please enter an all-caps identifier (may include digits and underscores): "
         end
       end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -276,7 +276,7 @@ module BranchIOCLI
       end
 
       def validate_test_configurations(options)
-        return unless options.test_configurations
+        return if options.test_configurations.nil?
         unless options.setting
           say "--test-configurations ignored without --setting"
           return

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -283,7 +283,7 @@ module BranchIOCLI
         end
 
         all_configurations = target.build_configurations.map(&:name)
-        test_configs = options.test_configurations
+        test_configs = options.test_configurations == false ? [] : options.test_configurations
         loop do
           invalid_configurations = test_configs.reject { |c| all_configurations.include? c }
           @test_configurations = test_configs and return if invalid_configurations.empty?

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -53,7 +53,12 @@ module BranchIOCLI
       end
 
       def log_xcodebuild_showbuildsettings(report = STDOUT)
-        report.write "$ #{xcodebuild_cmd}\n\n"
+        if report == STDOUT
+          say "<%= color('$ #{xcodebuild_cmd}', [MAGENTA, BOLD]) %>\n\n"
+        else
+          report.write "$ #{xcodebuild_cmd}\n\n"
+        end
+
         report.write @xcodebuild_showbuildsettings_output
         if valid?
           report.write "Success.\n\n"

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -5,14 +5,22 @@ module BranchIOCLI
   module Configuration
     class XcodeSettings
       class << self
+        def settings_for_config(configuration)
+          return @settings[configuration] if @settings && @settings[configuration]
+          @settings ||= {}
+
+          @settings[configuration] = self.new configuration
+        end
+
         def settings
-          return @settings if @settings
-          @settings = self.new
-          @settings
+          settings_for_config "Release"
         end
       end
 
-      def initialize
+      attr_reader :configuration
+
+      def initialize(configuration)
+        @configuration = configuration
         load_settings_from_xcode
       end
 
@@ -32,7 +40,7 @@ module BranchIOCLI
         cmd = "xcodebuild"
         cmd = "#{cmd} -project #{Shellwords.escape config.xcodeproj_path}"
         cmd += " -target #{Shellwords.escape config.target.name}"
-        cmd += " -configuration #{Shellwords.escape config.configuration}"
+        cmd += " -configuration #{Shellwords.escape configuration}"
         cmd += " -sdk #{Shellwords.escape config.sdk}"
         cmd += " -showBuildSettings"
         cmd

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -35,7 +35,7 @@ module BranchIOCLI
       def add_custom_build_setting
         return unless config.setting
 
-        config.target.build_configuration_list.each do |c|
+        config.target.build_configurations.each do |c|
           c.build_settings[config.setting] = c.debug? ? config.keys[:test] : config.keys[:live]
         end
       end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -32,13 +32,18 @@ module BranchIOCLI
         end.uniq.count > 1
       end
 
+      def uses_test_key?(build_configuration)
+        return build_configuration.debug? unless config.setting && config.test_configurations
+        config.test_configurations.include? build_configuration.name
+      end
+
       def add_custom_build_setting
         return unless config.setting
 
         config.target.build_configurations.each do |c|
-          key = c.debug? ? config.keys[:test] : config.keys[:live]
+          key = uses_test_key?(c) ? config.keys[:test] : config.keys[:live]
           # Reuse the same key if both not present
-          key ||= c.debug? ? config.keys[:live] : config.keys[:test]
+          key ||= uses_test_key?(c) ? config.keys[:live] : config.keys[:test]
           c.build_settings[config.setting] = key
         end
       end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -36,7 +36,10 @@ module BranchIOCLI
         return unless config.setting
 
         config.target.build_configurations.each do |c|
-          c.build_settings[config.setting] = c.debug? ? config.keys[:test] : config.keys[:live]
+          key = c.debug? ? config.keys[:test] : config.keys[:live]
+          # Reuse the same key if both not present
+          key ||= c.debug? ? config.keys[:live] : config.keys[:test]
+          c.build_settings[config.setting] = key
         end
       end
 

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -23,7 +23,7 @@ module BranchIOCLI
         end
 
         def use_conditional_test_key?
-          config.keys.count > 1 && !helper.has_multiple_info_plists?
+          config.keys.count > 1 && config.setting.nil? && !helper.has_multiple_info_plists?
         end
 
         def swift_file_includes_branch?(path)

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -137,7 +137,13 @@ module BranchIOCLI
           begin
             info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
             branch_key = info_plist["branch_key"]
-            report += " Branch key(s) (Info.plist):\n"
+            if config.branch_key_setting_from_info_plist
+              annotation = "[Info.plist:$(#{config.branch_key_setting_from_info_plist})]"
+            else
+              annotation = "(Info.plist)"
+            end
+
+            report += " Branch key(s) #{annotation}:\n"
             if branch_key.kind_of? Hash
               branch_key.each_key do |key|
                 resolved_key = helper.expand_build_settings branch_key[key], config.target, config.configuration

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -38,12 +38,21 @@ module BranchIOCLI
           cmd
         end
 
+        def report_scheme
+          report = "\nScheme #{config.scheme}:\n"
+          report += " Configurations:\n"
+          report += "  #{config.configurations_from_scheme.join("\n  ")}\n"
+          report
+        end
+
         # rubocop: disable Metrics/PerceivedComplexity
         def report_header
           header = "cocoapods-core: #{Pod::CORE_VERSION}\n"
 
           header += `xcodebuild -version`
           header += "SDK: #{xcode_settings['SDK_NAME']}\n" if xcode_settings
+
+          header += report_scheme
 
           configuration = config.configuration || "Release"
           configurations = config.configuration ? [config.configuration] : config.configurations_from_scheme

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -54,7 +54,7 @@ module BranchIOCLI
 
           header += report_scheme
 
-          configuration = config.configuration || "Release"
+          configuration = config.configuration || config.configurations_from_scheme.first
           configurations = config.configuration ? [config.configuration] : config.configurations_from_scheme
 
           bundle_identifier = helper.expanded_build_setting config.target, "PRODUCT_BUNDLE_IDENTIFIER", configuration
@@ -158,9 +158,9 @@ module BranchIOCLI
               info_plist = File.open(infoplist_path) { |f| Plist.parse_xml f }
               branch_key = info_plist["branch_key"]
               if config.branch_key_setting_from_info_plist(configuration)
-                annotation = "[Info.plist:$(#{config.branch_key_setting_from_info_plist})]"
+                annotation = "[#{File.basename infoplist_path}:$(#{config.branch_key_setting_from_info_plist})]"
               else
-                annotation = "(Info.plist)"
+                annotation = "(#{File.basename infoplist_path})"
               end
 
               report += "  Branch key(s) #{annotation}:\n"
@@ -196,7 +196,7 @@ module BranchIOCLI
             begin
               # This isn't likely to vary by configuration, so just report for one, either
               # whatever was passed or Release.
-              domains = helper.domains_from_project config.configuration || "Release"
+              domains = helper.domains_from_project config.configuration || config.configurations_from_scheme.first
               report += " Universal Link domains (entitlements):\n"
               domains.each do |domain|
                 report += "  #{domain}\n"

--- a/lib/branch_io_cli/version.rb
+++ b/lib/branch_io_cli/version.rb
@@ -1,3 +1,3 @@
 module BranchIOCLI
-  VERSION = "0.9.10"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
Introduced a `-s`/`--setting` flag to the setup command. This results in a new setting called `BRANCH_KEY` being added to the target with a different key per configuration. The name may be customized using an optional argument, e.g. `-s MY_BRANCH_KEY`. The `branch_key` in the Info.plist will be set to `$(BRANCH_KEY)`. By default, any debug configuration will use the test key for `$(BRANCH_KEY)`, and any release configuration will use the live key. This may be customized using the `--test-configurations` argument.

Now the report command shows all configurations for a scheme by default. The `--configuration` option overrides this. The report command will indicate the name of any build setting used to specify the `branch_key` in the Info.plist, and it will report the resolved key for each configuration.

This makes for more maintainable apps and more reliable reporting.

Bumped the version to 0.10.0.

Also added a `-o` option as an alias for `--out` in the report command. Pass `-o stdout` to stream the full report to the terminal.