### PR TITLE
Rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ that the relevant commands are available in your `PATH`.
 |--[no-]force|Update project even if Universal Link validation fails (default: no)|
 |--[no-]add-sdk|Add the Branch framework to the project (default: yes)|
 |--[no-]patch-source|Add Branch SDK calls to the AppDelegate (default: yes)|
-|--[no-]commit|Commit the results to Git (default: no)|
+|--[no-]commit [message]|Commit the results to Git (default: no)|
 
 All parameters are optional. A live key or test key, or both is required, as well as at least one domain.
 Specify --live-key, --test-key or both and --app-link-subdomain, --domains or both. If these are not

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,14 @@ RSpec::Core::RakeTask.new
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
+require 'branch_io_cli/rake_task'
+BranchIOCLI::RakeTask.new
+
 task default: [:spec, :rubocop]
+
+ALL_PROJECTS = Dir[File.expand_path("../examples/*Example*", __FILE__)]
+desc "Report on all examples in repo"
+task :report do
+  puts "All examples: #{ALL_PROJECTS}"
+  Rake::Task["branch:report"].invoke ALL_PROJECTS
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,13 +11,22 @@ BranchIOCLI::RakeTask.new
 
 task default: [:spec, :rubocop]
 
-ALL_PROJECTS = Dir[File.expand_path("../examples/*Example*", __FILE__)]
+IOS_REPO_DIR = File.expand_path "../../ios-branch-deep-linking", __FILE__
+
+def all_projects
+  projects = Dir[File.expand_path("../examples/*Example*", __FILE__)]
+  if Dir.exist? IOS_REPO_DIR
+    projects += Dir[File.expand_path("{Branch-TestBed*,Examples/*}", IOS_REPO_DIR)].reject { |p| p =~ /Xcode-7|README/ }
+  end
+  projects
+end
+
 desc "Report on all examples in repo"
 task :report do
-  Rake::Task["branch:report"].invoke ALL_PROJECTS, true, true
+  Rake::Task["branch:report"].invoke all_projects, header_only: true
 end
 
 desc "Perform a full build of all examples in the repo"
 task "report:full" do
-  Rake::Task["branch:report"].invoke ALL_PROJECTS, true, false, "./report.txt", false
+  Rake::Task["branch:report"].invoke all_projects, pod_repo_update: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,10 @@ task default: [:spec, :rubocop]
 ALL_PROJECTS = Dir[File.expand_path("../examples/*Example*", __FILE__)]
 desc "Report on all examples in repo"
 task :report do
-  puts "All examples: #{ALL_PROJECTS}"
-  Rake::Task["branch:report"].invoke ALL_PROJECTS
+  Rake::Task["branch:report"].invoke ALL_PROJECTS, true, true
+end
+
+desc "Perform a full build of all examples in the repo"
+task "report:full" do
+  Rake::Task["branch:report"].invoke ALL_PROJECTS, true, false, "./report.txt", false
 end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -92,7 +92,7 @@ EOF
         c.option "--[no-]force", "Update project even if Universal Link validation fails (default: no)"
         c.option "--[no-]add-sdk", "Add the Branch framework to the project (default: yes)"
         c.option "--[no-]patch-source", "Add Branch SDK calls to the AppDelegate (default: yes)"
-        c.option "--[no-]commit", "Commit the results to Git (default: no)"
+        c.option "--[no-]commit [message]", String, "Commit the results to Git (default: no)"
 
         c.example "Test without validation (can use dummy keys and domains)", "branch_io setup -L key_live_xxxx -D myapp.app.link --no-validate"
         c.example "Use both live and test keys", "branch_io setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link"

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -7,6 +7,10 @@ module BranchIOCLI
         say "\n"
 
         say "Loading settings from Xcode"
+        # In case running in a non-CLI context (e.g., Rake or Fastlane) be sure
+        # to reset Xcode settings each time, since project, target and
+        # configurations will change.
+        Configuration::XcodeSettings.reset
         if Configuration::XcodeSettings.all_valid?
           say "Done ✅"
         else

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -15,7 +15,7 @@ module BranchIOCLI
 
         if config.header_only
           say report_helper.report_header
-          exit 0
+          return
         end
 
         if config.report_path == "stdout"

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -30,9 +30,7 @@ module BranchIOCLI
           say "Universal Link configuration passed validation. ✅"
         end
 
-        begin
-          config.xcodeproj.build_configurations.first.debug?
-        rescue RuntimeError
+        if File.exist?(config.podfile_path) && config.pod_install_required?
           helper.verify_cocoapods
           say "Installing pods to resolve current build settings"
           Dir.chdir(File.dirname(config.podfile_path)) do

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -30,7 +30,7 @@ module BranchIOCLI
           say "Universal Link configuration passed validation. ✅"
         end
 
-        if File.exist?(config.podfile_path) && config.pod_install_required?
+        if config.podfile_path && File.exist?(config.podfile_path) && config.pod_install_required?
           helper.verify_cocoapods
           say "Installing pods to resolve current build settings"
           Dir.chdir(File.dirname(config.podfile_path)) do
@@ -76,7 +76,10 @@ module BranchIOCLI
 
         changes = helper.changes.to_a.map { |c| Pathname.new(File.expand_path(c)).relative_path_from(Pathname.pwd).to_s }
 
-        sh "git commit -qm '[branch_io_cli] Branch SDK integration' #{changes.join(' ')}"
+        commit_message = options.commit if options.commit.kind_of?(String)
+        commit_message ||= "[branch_io_cli] Branch SDK integration #{config.relative_path(config.xcodeproj_path)} (#{config.target.name})"
+
+        sh "git commit -qm #{Shellwords.escape commit_message} #{changes.join(' ')}"
       end
       # rubocop: enable Metrics/PerceivedComplexity
 

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -334,16 +334,16 @@ EOF
         "#{version} [Cartfile.resolved]"
       end
 
-      def version_from_branch_framework(config = configurations.first)
+      def version_from_branch_framework(configuration = configurations.first)
         framework = target.frameworks_build_phase.files.find { |f| f.file_ref.path =~ /Branch.framework$/ }
         return nil unless framework
 
         if framework.file_ref.isa == "PBXFileReference"
-          project_path = relative_path(config.xcodeproj_path)
+          project_path = relative_path(xcodeproj_path)
           framework_path = framework.file_ref.real_path
-        elsif framework.file_ref.isa == "PBXReferenceProxy" && XcodeSettings[config].valid?
+        elsif framework.file_ref.isa == "PBXReferenceProxy" && XcodeSettings[configuration].valid?
           project_path = relative_path framework.file_ref.remote_ref.proxied_object.project.path
-          framework_path = File.expand_path framework.file_ref.path, XcodeSettings[config][framework.file_ref.source_tree]
+          framework_path = File.expand_path framework.file_ref.path, XcodeSettings[configuration][framework.file_ref.source_tree]
         end
         return nil unless framework_path
         info_plist_path = File.join framework_path.to_s, "Info.plist"

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -19,6 +19,10 @@ module BranchIOCLI
 
           @settings[configuration] = self.new configuration
         end
+
+        def reset
+          @settings = {}
+        end
       end
 
       attr_reader :configuration

--- a/lib/branch_io_cli/rake_task.rb
+++ b/lib/branch_io_cli/rake_task.rb
@@ -1,0 +1,29 @@
+require "rake"
+require "rake/tasklib"
+require "branch_io_cli"
+require "branch_io_cli/helper/methods"
+require "highline/import"
+
+module BranchIOCLI
+  class RakeTask < Rake::TaskLib
+    def initialize(*args, &b)
+      namespace :branch do
+        report_task
+      end
+    end
+
+    def report_task
+      desc "Generate a brief Branch report"
+      task :report, %i{paths} do |task, args|
+        paths = args[:paths]
+        paths = [paths] unless paths.respond_to?(:each)
+
+        paths.each do |path|
+          Dir.chdir(path) do
+            STDOUT.log_command "branch_io report -H -t"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/branch_io_cli/rake_task.rb
+++ b/lib/branch_io_cli/rake_task.rb
@@ -1,11 +1,25 @@
 require "rake"
 require "rake/tasklib"
 require "branch_io_cli"
-require "branch_io_cli/helper/methods"
 require "highline/import"
 
 module BranchIOCLI
   class RakeTask < Rake::TaskLib
+    ReportOptions = Struct.new(
+      :cartfile,
+      :clean,
+      :configuration,
+      :header_only,
+      :out,
+      :pod_repo_update,
+      :podfile,
+      :scheme,
+      :sdk,
+      :target,
+      :xcodeproj,
+      :workspace
+    )
+
     def initialize(*args, &b)
       namespace :branch do
         report_task
@@ -14,13 +28,30 @@ module BranchIOCLI
 
     def report_task
       desc "Generate a brief Branch report"
-      task :report, %i{paths} do |task, args|
+      task :report, %i{paths clean header_only out pod_repo_update sdk} do |task, args|
         paths = args[:paths]
         paths = [paths] unless paths.respond_to?(:each)
+        clean = args[:clean].nil? ? true : args[:clean]
+        repo_update = args[:pod_repo_update].nil? ? true : args[:pod_repo_update]
+
+        options = ReportOptions.new(
+          nil,
+          clean,
+          nil,
+          args[:header_only],
+          args[:out] || "./report.txt",
+          repo_update,
+          nil,
+          nil,
+          args[:sdk] || "iphonesimulator",
+          nil,
+          nil,
+          nil
+        )
 
         paths.each do |path|
           Dir.chdir(path) do
-            STDOUT.log_command "branch_io report -H -t"
+            Command::ReportCommand.new(options).run!
           end
         end
       end


### PR DESCRIPTION
Fixed a crash with the setup command when not using CocoaPods.

Added an optional custom commit message to the `setup --commit` option and improved the default one.

Added a `branch:report` Rake task.