### PR TITLE
Confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|BRANCH_APP_LINK_SUBDOMAIN|
 |-U, --uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|BRANCH_URI_SCHEME|
 |-s, --setting [BRANCH_KEY_SETTING]|Use a custom build setting for the Branch key (default: Use Info.plist)|BRANCH_SETTING|
-|--test-configurations config1,config2|List of configurations that use the test key with a custom build setting (default: Debug configurations)|BRANCH_TEST_CONFIGURATIONS|
+|--[no-]test-configurations [config1,config2]|List of configurations that use the test key with a custom build setting (default: Debug configurations)|BRANCH_TEST_CONFIGURATIONS|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|BRANCH_XCODEPROJ|
 |--target MyAppTarget|Name of a target to modify in the Xcode project|BRANCH_TARGET|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|BRANCH_PODFILE|
@@ -149,6 +149,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |--[no-]patch-source|Add Branch SDK calls to the AppDelegate (default: yes)|BRANCH_PATCH_SOURCE|
 |--commit [message]|Commit the results to Git|BRANCH_COMMIT|
 |--[no-]check-repo-changes|Check for uncommitted changes to a git repo (default: yes)|BRANCH_CHECK_REPO_CHANGES|
+|--[no-]confirm|Confirm configuration before proceeding (default: yes)|BRANCH_CONFIRM|
 
 
 #### Examples

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -13,7 +13,7 @@ _branch_io_complete()
 
     setup_opts="$global_opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
     setup_opts="$setup_opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
-    setup_opts="$setup_opts --test-configurations --no-test-configurations --no-check-repo-changes"
+    setup_opts="$setup_opts --test-configurations --no-test-configurations --no-check-repo-changes --no-confirm"
     # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
     setup_opts="$setup_opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/assets/completions/completion.zsh
+++ b/lib/assets/completions/completion.zsh
@@ -6,7 +6,7 @@ _branch_io_complete() {
   opts="-h --help -t --trace -v --version"
   opts="$opts -L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme"
   opts="$opts --xcodeproj --target --frameworks --podfile --cartfile --carthage-command --setting -s"
-  opts="$opts --test-configurations --no-test-configurations --no-check-repo-changes"
+  opts="$opts --test-configurations --no-test-configurations --no-check-repo-changes --no-confirm"
   # Don't autocomplete the default values here, e.g. --no-force, --pod-repo-update.
   opts="$opts --no-add-sdk --no-validate --force --no-pod-repo-update --commit --no-patch-source"
 

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -43,11 +43,7 @@ module BranchIOCLI
           c.action do |args, options|
             options.default configuration_class.defaults
             return_value = command_class.new(options).run!
-            exit(0) unless configuration_class.respond_to?(:return_map) &&
-                           configuration_class.return_map &&
-                           configuration_class.return_map.respond_to?(:[])
-
-            exit configuration_class.return_map[return_value]
+            exit(return_value.respond_to?(:to_i) ? return_value.to_i : 0)
           end
         end
       end

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -5,7 +5,7 @@ require "branch_io_cli/format"
 module BranchIOCLI
   class CLI
     include Commander::Methods
-    include Format::CommanderFormat
+    include Format::HighlineFormat
 
     def run
       program :name, "Branch.io command-line interface"

--- a/lib/branch_io_cli/cli.rb
+++ b/lib/branch_io_cli/cli.rb
@@ -43,11 +43,11 @@ module BranchIOCLI
           c.action do |args, options|
             options.default configuration_class.defaults
             return_value = command_class.new(options).run!
-            exit(0) unless configuration_class.respond_to?(:return_value_map) &&
-                           configuration_class.return_value_map &&
-                           configuration_class.return_value_map.respond_to?(:[])
+            exit(0) unless configuration_class.respond_to?(:return_map) &&
+                           configuration_class.return_map &&
+                           configuration_class.return_map.respond_to?(:[])
 
-            exit configuration_class.return_value_map[return_value]
+            exit configuration_class.return_map[return_value]
           end
         end
       end

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -19,7 +19,7 @@ module BranchIOCLI
 
         if config.header_only
           say report_helper.report_header
-          return
+          return 0
         end
 
         if config.report_path == "stdout"
@@ -28,6 +28,8 @@ module BranchIOCLI
           File.open(config.report_path, "w") { |f| write_report f }
           say "Report generated in #{config.report_path}"
         end
+
+        0
       end
 
       def write_report(report)

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -22,7 +22,7 @@ module BranchIOCLI
            !helper.validate_team_and_bundle_ids_from_aasa_files(@domains)
           say "Universal Link configuration failed validation."
           helper.errors.each { |error| say " #{error}" }
-          return unless options.force
+          return 1 unless options.force
         elsif is_app_target && options.validate
           say "Universal Link configuration passed validation. ✅"
         end
@@ -69,7 +69,7 @@ module BranchIOCLI
 
         patch_helper.patch_source xcodeproj if options.patch_source
 
-        return unless options.commit
+        return 0 unless options.commit
 
         changes = helper.changes.to_a.map { |c| Pathname.new(File.expand_path(c)).relative_path_from(Pathname.pwd).to_s }
 
@@ -77,6 +77,8 @@ module BranchIOCLI
         commit_message ||= "[branch_io_cli] Branch SDK integration #{config.relative_path(config.xcodeproj_path)} (#{config.target.name})"
 
         sh ["git", "commit", "-qm", commit_message, *changes]
+
+        0
       end
       # rubocop: enable Metrics/PerceivedComplexity
 

--- a/lib/branch_io_cli/command/validate_command.rb
+++ b/lib/branch_io_cli/command/validate_command.rb
@@ -4,8 +4,8 @@ module BranchIOCLI
       def run!
         valid = true
 
-        unless options.domains.nil? || options.domains.empty?
-          domains_valid = helper.validate_project_domains(options.domains)
+        unless config.domains.nil? || config.domains.empty?
+          domains_valid = helper.validate_project_domains(config.domains)
 
           if domains_valid
             say "Project domains match :domains parameter: ✅"

--- a/lib/branch_io_cli/command/validate_command.rb
+++ b/lib/branch_io_cli/command/validate_command.rb
@@ -27,7 +27,7 @@ module BranchIOCLI
 
         say "Universal Link configuration passed validation. ✅" if valid
 
-        valid
+        valid ? 0 : 1
       end
     end
   end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -449,7 +449,7 @@ EOF
           end
           new_value = ask "Please enter one or more of the above, separated by commas: ", Array
         elsif option.type.nil?
-          new_value = agree "#{option.name.to_s.gsub(/_/, ' ').capitalize}? "
+          new_value = agree "#{option.name.to_s.gsub(/_/, ' ').capitalize} (y/n)? "
         else
           new_value = ask "Please enter a new value for #{option.name.to_s.gsub(/_/, ' ').capitalize}: ", option.type
         end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -405,7 +405,7 @@ EOF
           choice = choose do |menu|
             self.class.available_options.reject { |o| o.name == :confirm }.each do |option|
               value = send option.confirm_symbol
-              menu.choice "#{option.name.to_s.gsub(/_/, ' ').capitalize}: #{value.nil? ? '(none)' : value}"
+              menu.choice "#{option.name.to_s.gsub(/_/, ' ').capitalize}: #{option.display_value(value)}"
             end
 
             menu.choice "Accept and continue"
@@ -436,7 +436,7 @@ EOF
         say "#{option.description}\n\n"
         value = send option.confirm_symbol
         say "<%= color('Type', BOLD) %>: #{option.ui_type}\n"
-        say "<%= color('Current value', BOLD) %>: #{value.nil? ? '(none)' : value}\n\n"
+        say "<%= color('Current value', BOLD) %>: #{option.display_value(value)}\n\n"
 
         valid_values = option.valid_values
 

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -417,6 +417,7 @@ EOF
               say "Invalid value for option."
             end
           elsif choice =~ /^Accept/
+            log
             return
           else
             exit(0)

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -64,7 +64,8 @@ module BranchIOCLI
 
       def initialize(options)
         @options = options
-        @pod_repo_update = options.pod_repo_update if options.respond_to?(:pod_repo_update)
+        @pod_repo_update = options.pod_repo_update if self.class.available_options.map(&:name).include?(:pod_repo_update)
+
         Configuration.current = self
 
         print_identification self.class.name.sub(/^.*::(.*?)Configuration$/, '\1').downcase
@@ -382,10 +383,9 @@ EOF
         all_options = self.class.available_options.map(&:name)
         return super unless all_options.include?(method_sym)
 
+        # Define an attr_reader for this method
         self.class.send :define_method, method_sym do
-          ivar = "@#{method_sym}"
-          value = instance_variable_get ivar
-          value
+          instance_variable_get "@#{method_sym}"
         end
 
         send method_sym
@@ -448,7 +448,7 @@ EOF
             say "#{v}\n"
           end
           new_value = ask "Please enter one or more of the above, separated by commas: ", Array
-        elsif valid_values
+        elsif option.type.nil?
           new_value = agree "#{option.name.to_s.gsub(/_/, ' ').capitalize}? "
         else
           new_value = ask "Please enter a new value for #{option.name.to_s.gsub(/_/, ' ').capitalize}: ", option.type

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -2,10 +2,13 @@ require "cocoapods-core"
 require "pathname"
 require "xcodeproj"
 
+require "branch_io_cli/helper/methods"
+
 module BranchIOCLI
   module Configuration
     # rubocop: disable Metrics/ClassLength
     class Configuration
+
       class << self
         attr_accessor :current
 
@@ -397,7 +400,8 @@ EOF
         return unless confirmed == false
 
         loop do
-          say "\n<%= color('The following options may be adjusted before continuing.', BOLD) %>"
+          clear
+          say "<%= color('The following options may be adjusted before continuing.', BOLD) %>"
           choice = choose do |menu|
             self.class.available_options.reject { |o| o.name == :confirm }.each do |option|
               value = send option.confirm_symbol
@@ -426,7 +430,8 @@ EOF
       end
 
       def prompt_for_option(option)
-        say "\n<%= color('#{option.name.to_s.gsub(/_/, ' ').capitalize}', BOLD) %>\n\n"
+        clear
+        say "<%= color('#{option.name.to_s.gsub(/_/, ' ').capitalize}', BOLD) %>\n\n"
         say "#{option.description}\n\n"
         value = send option.confirm_symbol
         say "<%= color('Type', BOLD) %>: #{option.ui_type}\n"

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -4,6 +4,7 @@ require "xcodeproj"
 
 module BranchIOCLI
   module Configuration
+    # rubocop: disable Metrics/ClassLength
     class Configuration
       class << self
         attr_accessor :current
@@ -21,6 +22,31 @@ module BranchIOCLI
 
             defs.merge(o.name => default_value)
           end
+        end
+
+        def absolute_path(path)
+          return path unless current
+          current.absolute_path path
+        end
+
+        def relative_path(path)
+          return path unless current
+          current.relative_path path
+        end
+
+        def open_podfile(path)
+          return false unless current
+          current.open_podfile absolute_path path
+        end
+
+        def open_xcodeproj(path)
+          return false unless current
+          current.open_xcodeproj absolute_path path
+        end
+
+        def root
+          return nil unless current
+          current.root
         end
       end
 
@@ -429,5 +455,6 @@ EOF
         true
       end
     end
+    # rubocop: enable Metrics/ClassLength
   end
 end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -401,6 +401,7 @@ EOF
 
         loop do
           clear
+
           say "<%= color('The following options may be adjusted before continuing.', BOLD) %>"
           choice = choose do |menu|
             self.class.available_options.reject { |o| o.name == :confirm }.each do |option|
@@ -413,12 +414,14 @@ EOF
             menu.prompt = "What would you like to do?"
           end
 
+          clear
+
           selected_sym = choice.sub(/:.*$/, '').gsub(/\s/, '_').downcase.to_sym
 
           if (option = self.class.available_options.find { |o| o.name == selected_sym })
             loop do
               break if prompt_for_option(option)
-              say "Invalid value for option."
+              say "Invalid value for option.\n\n"
             end
           elsif choice =~ /^Accept/
             log
@@ -430,7 +433,6 @@ EOF
       end
 
       def prompt_for_option(option)
-        clear
         say "<%= color('#{option.name.to_s.gsub(/_/, ' ').capitalize}', BOLD) %>\n\n"
         say "#{option.description}\n\n"
         value = send option.confirm_symbol

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -8,7 +8,6 @@ module BranchIOCLI
   module Configuration
     # rubocop: disable Metrics/ClassLength
     class Configuration
-
       class << self
         attr_accessor :current
 

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -53,9 +53,7 @@ module BranchIOCLI
       end
 
       def env_value
-        return nil unless env_name
-        value = convert ENV[env_name]
-        value if valid?(value)
+        ENV[env_name] if env_name
       end
 
       def convert(value)

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -81,8 +81,10 @@ module BranchIOCLI
         return validate_proc.call(value) if validate_proc
 
         value = convert value
-        if valid_values
+        if valid_values && type != Array
           valid_values.include? value
+        elsif valid_values
+          value.all? { |v| valid_values.include?(v) }
         elsif type
           value.kind_of? type
         else

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -64,7 +64,7 @@ module BranchIOCLI
         if type == Array
           value = value.split(",") if value.kind_of?(String)
         elsif type == String
-          value = value.strip
+          value = value.strip if value.kind_of?(String)
         elsif type.nil?
           value = true if value.kind_of?(String) && value =~ /^(true|yes)$/i
           value = false if value.kind_of?(String) && value =~ /^(false|no)$/i

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -53,7 +53,7 @@ module BranchIOCLI
       end
 
       def env_value
-        ENV[env_name] if env_name
+        convert(ENV[env_name]) if env_name
       end
 
       def convert(value)

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -71,6 +71,16 @@ module BranchIOCLI
         value
       end
 
+      def display_value(value)
+        if type.nil?
+          value ? "yes" : "no"
+        elsif value.nil?
+          "(none)"
+        else
+          value.to_s
+        end
+      end
+
       def valid?(value)
         return validate_proc.call(value) if validate_proc
 

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -10,12 +10,14 @@ module BranchIOCLI
       attr_accessor :argument_optional
       attr_accessor :aliases
       attr_accessor :negatable
+      attr_accessor :confirm_symbol
+      attr_accessor :valid_values_proc
+      attr_accessor :validate_proc
+      attr_accessor :convert_proc
 
       def initialize(options)
         @name = options[:name]
         @env_name = options[:env_name]
-        @env_name = "BRANCH_#{@name.to_s.upcase}" if @env_name.nil?
-
         @type = options[:type]
         @description = options[:description]
         @default_value = options[:default_value]
@@ -24,19 +26,68 @@ module BranchIOCLI
         @aliases = options[:aliases] || []
         @aliases = [@aliases] unless @aliases.kind_of?(Array)
         @negatable = options[:type].nil? if options[:negatable].nil?
+        @confirm_symbol = options[:confirm_symbol] || @name
+        @valid_values_proc = options[:valid_values_proc]
+        @validate_proc = options[:validate_proc]
+        @convert_proc = options[:convert_proc]
 
+        raise ArgumentError, "Use :validate_proc or :valid_values_proc, but not both." if @valid_values_proc && @validate_proc
+
+        @env_name = "BRANCH_#{@name.to_s.upcase}" if @env_name.nil?
         @argument_optional ||= @negatable
+      end
+
+      def valid_values
+        if valid_values_proc && valid_values_proc.kind_of?(Proc)
+          valid_values_proc.call
+        elsif type.nil?
+          [true, false]
+        end
+      end
+
+      def ui_type
+        case type
+        when nil
+          "Boolean"
+        when Array
+          "Comma-separated list"
+        else
+          type.to_s
+        end
       end
 
       def env_value
         return nil unless env_name
-        default_value = ENV[env_name]
-        default_value = default_value.split(",") if type == Array && default_value.kind_of?(String)
-        if type.nil? && default_value.kind_of?(String)
-          default_value = true if default_value =~ /^(true|yes)$/i
-          default_value = false if default_value =~ /^(false|no)$/i
+        convert ENV[env_name]
+      end
+
+      def convert(value)
+        return convert_proc.call(value) if convert_proc
+
+        case type
+        when Array
+          value = value.split(",") if value.kind_of?(String)
+        when String
+          value = value.strip
+        when nil
+          value = true if value.kind_of?(String) && value =~ /^(true|yes)$/i
+          value = false if value.kind_of?(String) && value =~ /^(false|no)$/i
         end
-        default_value
+
+        value
+      end
+
+      def valid?(value)
+        return validate_proc.call(value) if validate_proc
+
+        value = convert value
+        if valid_values
+          valid_values.include? value
+        elsif type
+          value.kind_of? type
+        else
+          value == true || value == false
+        end
       end
     end
   end

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -54,7 +54,8 @@ module BranchIOCLI
 
       def env_value
         return nil unless env_name
-        convert ENV[env_name]
+        value = convert ENV[env_name]
+        value if valid?(value)
       end
 
       def convert(value)

--- a/lib/branch_io_cli/configuration/option_wrapper.rb
+++ b/lib/branch_io_cli/configuration/option_wrapper.rb
@@ -22,6 +22,7 @@ module BranchIOCLI
 
         value = hash[method_sym]
         return value unless add_defaults && value.nil?
+
         default_value = option.env_value
         default_value = option.default_value if default_value.nil?
         default_value

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -46,6 +46,10 @@ module BranchIOCLI
     # rubocop: disable Metrics/ClassLength
     class ReportConfiguration < Configuration
       class << self
+        def summary
+          "Generate and optionally submit a build diagnostic report."
+        end
+
         def available_options
           [
             Option.new(

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -3,6 +3,10 @@ module BranchIOCLI
     # rubocop: disable Metrics/ClassLength
     class SetupConfiguration < Configuration
       class << self
+        def summary
+          "Integrates the Branch SDK into a native app project"
+        end
+
         def examples
           {
             "Test without validation (can use dummy keys and domains)" => "branch_io setup -L key_live_xxxx -D myapp.app.link --no-validate",

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -187,6 +187,7 @@ module BranchIOCLI
         @add_sdk = options.add_sdk
         @force = options.force
         @commit = options.commit
+        @check_repo_changes = options.check_repo_changes
 
         say "--force is ignored when --no-validate is used." if !options.validate && options.force
         if options.cartfile && options.podfile
@@ -292,6 +293,7 @@ module BranchIOCLI
           key = ask "Please enter your #{type} Branch key or use --#{type}-key [enter for none]: "
         end
         @keys[type] = key unless key.empty?
+        instance_variable_set "@#{type}_key", key
       end
 
       def validate_all_domains(options, required = true)

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -67,7 +67,8 @@ module BranchIOCLI
               description: "List of configurations that use the test key with a custom build setting (default: Debug configurations)",
               example: "config1,config2",
               type: Array,
-              negatable: true
+              negatable: true,
+              valid_values_proc: ->() { Configuration.current.xcodeproj.build_configurations.map(&:name) }
             ),
             Option.new(
               name: :xcodeproj,
@@ -99,8 +100,8 @@ module BranchIOCLI
               example: "/path/to/Cartfile",
               type: String,
               confirm_symbol: :cartfile_path,
-              validate_proc: ->(path) { path && File.exist?(path.to_s) },
-              convert_proc: ->(path) { Configuration.absolute_path path.to_s }
+              validate_proc: ->(path) { !path.nil? && File.exist?(path.to_s) },
+              convert_proc: ->(path) { Configuration.absolute_path(path.to_s) unless path.nil? }
             ),
             Option.new(
               name: :carthage_command,

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -75,8 +75,7 @@ module BranchIOCLI
               example: "MyProject.xcodeproj",
               type: String,
               confirm_symbol: :xcodeproj_path,
-              validate_proc: ->(path) { Configuration.current.open_xcodeproj path }
-              convert_proc: ->(path) { Configuration.current.absolute_path(path.to_s) if Configuration.current }
+              validate_proc: ->(path) { Configuration.open_xcodeproj path }
             ),
             Option.new(
               name: :target,
@@ -92,8 +91,7 @@ module BranchIOCLI
               example: "/path/to/Podfile",
               type: String,
               confirm_symbol: :podfile_path,
-              validate_proc: ->(path) { Configuration.current.open_podfile path },
-              convert_proc: ->(path) { Configuration.current.absolute_path(path.to_s) if Configuration.current }
+              validate_proc: ->(path) { Configuration.open_podfile path }
             ),
             Option.new(
               name: :cartfile,
@@ -101,8 +99,8 @@ module BranchIOCLI
               example: "/path/to/Cartfile",
               type: String,
               confirm_symbol: :cartfile_path,
-              validate_proc: ->(path) { File.exist? path },
-              convert_proc: ->(path) { Configuration.current.absolute_path(path.to_s) if Configuration.current }
+              validate_proc: ->(path) { path && File.exist?(path.to_s) },
+              convert_proc: ->(path) { Configuration.absolute_path path.to_s }
             ),
             Option.new(
               name: :carthage_command,

--- a/lib/branch_io_cli/configuration/validate_configuration.rb
+++ b/lib/branch_io_cli/configuration/validate_configuration.rb
@@ -10,13 +10,6 @@ module BranchIOCLI
           "If validation passes, this command returns 0. If validation fails, it returns 1."
         end
 
-        def return_map
-          {
-            true => 0,
-            false => 1
-          }
-        end
-
         def available_options
           [
             Option.new(

--- a/lib/branch_io_cli/configuration/validate_configuration.rb
+++ b/lib/branch_io_cli/configuration/validate_configuration.rb
@@ -10,10 +10,10 @@ module BranchIOCLI
           "If validation passes, this command returns 0. If validation fails, it returns 1."
         end
 
-        def return_map(value)
+        def return_map
           {
             true => 0,
-            false => -1
+            false => 1
           }
         end
 

--- a/lib/branch_io_cli/configuration/validate_configuration.rb
+++ b/lib/branch_io_cli/configuration/validate_configuration.rb
@@ -2,8 +2,19 @@ module BranchIOCLI
   module Configuration
     class ValidateConfiguration < Configuration
       class << self
+        def summary
+          "Validates all Universal Link domains configured in a project"
+        end
+
         def return_value
           "If validation passes, this command returns 0. If validation fails, it returns 1."
+        end
+
+        def return_map(value)
+          {
+            true => 0,
+            false => -1
+          }
         end
 
         def available_options

--- a/lib/branch_io_cli/format.rb
+++ b/lib/branch_io_cli/format.rb
@@ -1,4 +1,4 @@
-require "branch_io_cli/format/commander_format"
+require "branch_io_cli/format/highline_format"
 require "branch_io_cli/format/markdown_format"
 
 module BranchIOCLI

--- a/lib/branch_io_cli/format/highline_format.rb
+++ b/lib/branch_io_cli/format/highline_format.rb
@@ -2,7 +2,7 @@ require "erb"
 
 module BranchIOCLI
   module Format
-    module CommanderFormat
+    module HighlineFormat
       include Format
 
       def header(text, level = 1)

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -713,8 +713,8 @@ EOF
           exit(-1)
         end
 
-        install = ask "'pod' command not available in PATH. Install cocoapods (may require a sudo password) (Y/n)? "
-        if install.downcase =~ /^n/
+        install = agree "'pod' command not available in PATH. Install cocoapods (may require a sudo password) (Y/n)? "
+        if install == false
           say "Please install cocoapods or use --no-add-sdk to continue."
           exit(-1)
         end
@@ -740,8 +740,8 @@ EOF
           exit(-1)
         end
 
-        install = ask "'carthage' command not available in PATH. Use Homebrew to install carthage (Y/n)? "
-        if install.downcase =~ /^n/
+        install = agree "'carthage' command not available in PATH. Use Homebrew to install carthage (Y/n)? "
+        if install == false
           say "Please install carthage or use --no-add-sdk to continue."
           exit(-1)
         end
@@ -761,8 +761,8 @@ EOF
           exit(-1)
         end
 
-        install = ask "'git' command not available in PATH. Install Xcode command-line tools (requires password) (Y/n)? "
-        if install.downcase =~ /^n/
+        install = agree "'git' command not available in PATH. Install Xcode command-line tools (requires password) (Y/n)? "
+        if install == false
           say "Please install Xcode command tools or leave out the --commit option to continue."
           exit(-1)
         end

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -25,6 +25,11 @@ module BranchIOCLI
         status = output.log_command command
         raise CommandError, [%{Error executing "#{command}": #{status}.}, status] unless status.success?
       end
+
+      # Clear the screen and move the cursor to the top using highline
+      def clear
+        say "\e[2J\e[H"
+      end
     end
   end
 end

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -215,8 +215,8 @@ module BranchIOCLI
           return unless config.pod_install_required?
           # Only if a Podfile is detected/supplied at the command line.
           say "pod install required in order to build."
-          install = ask %{Run "pod install" now (Y/n)? }
-          if install.downcase =~ /^n/
+          install = agree %{Run "pod install" now (Y/n)? }
+          if install == false
             say %{Please run "pod install" or "pod update" first in order to continue.}
             exit(-1)
           end

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -74,13 +74,26 @@ describe BranchIOCLI::Configuration::Option do
   end
 
   describe '#env_value' do
-    it 'returns the value of the named env. var. if set' do
-      option = OPTION_CLASS.new env_name: "USER"
-      expect(option.env_value).to eq ENV["USER"]
+    it 'returns the value of the named env. var. if set and valid' do
+      ENV["FOO"] = "bar"
+      option = OPTION_CLASS.new env_name: "FOO", type: String
+      expect(option.env_value).to eq "bar"
     end
 
     it 'returns nil if env_name is falsy' do
       option = OPTION_CLASS.new env_name: false
+      expect(option.env_value).to be_nil
+    end
+
+    it 'converts the value of env_name' do
+      ENV["FOO"] = "a,b,c"
+      option = OPTION_CLASS.new env_name: "FOO", type: Array
+      expect(option.env_value).to eq %w(a b c)
+    end
+
+    it 'returns nil unless env_name is valid' do
+      ENV["FOO"] = "a,b,c"
+      option = OPTION_CLASS.new env_name: "FOO", type: Array, validate_proc: ->(v) { false }
       expect(option.env_value).to be_nil
     end
   end

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -1,0 +1,150 @@
+describe BranchIOCLI::Configuration::Option do
+  describe 'initialization' do
+    OPTION_CLASS = BranchIOCLI::Configuration::Option
+
+    it 'raises if both :validate_proc and :valid_values are passed' do
+      expect do
+        OPTION_CLASS.new valid_values_proc: ->() {}, validate_proc: ->(x) {}
+      end.to raise_error ArgumentError
+    end
+
+    it 'sets negatable to true by default if type is nil' do
+      option = OPTION_CLASS.new({})
+      expect(option.negatable).to be true
+    end
+
+    it 'sets argument_optional to false if type is non-nil and negatable is false' do
+      option = OPTION_CLASS.new type: String
+      expect(option.argument_optional).to be false
+    end
+
+    it 'sets argument_optional to true if negatable is true' do
+      option = OPTION_CLASS.new negatable: true
+      expect(option.argument_optional).to be true
+    end
+
+    it 'sets confirm_symbol to name by default' do
+      option = OPTION_CLASS.new name: :foo
+      expect(option.confirm_symbol).to eq :foo
+    end
+
+    it 'sets aliases to an Array if a scalar is passed' do
+      option = OPTION_CLASS.new aliases: "-x"
+      expect(option.aliases).to eq %w(-x)
+    end
+
+    it 'accepts an Array for aliases' do
+      option = OPTION_CLASS.new aliases: %w(-x)
+      expect(option.aliases).to eq %w(-x)
+    end
+
+    it 'uses name to set env_name by default' do
+      option = OPTION_CLASS.new name: :foo
+      expect(option.env_name).to eq "BRANCH_FOO"
+    end
+  end
+
+  describe '#valid_values' do
+    it 'calls the valid_values_proc if present' do
+      option = OPTION_CLASS.new valid_values_proc: ->() { %w(a b c) }
+      expect(option.valid_values).to eq %w(a b c)
+    end
+
+    it 'returns nil for valid_values if valid_values_proc is nil' do
+      option = OPTION_CLASS.new({})
+      expect(option.valid_values).to be_nil
+    end
+  end
+
+  describe '#ui_type' do
+    it 'returns "Comma-separated list" for Array type' do
+      option = OPTION_CLASS.new type: Array
+      expect(option.ui_type).to eq "Comma-separated list"
+    end
+
+    it 'returns "Boolean" for nil type' do
+      option = OPTION_CLASS.new({})
+      expect(option.ui_type).to eq "Boolean"
+    end
+
+    it 'returns the name of the type for any other type' do
+      option = OPTION_CLASS.new type: String
+      expect(option.ui_type).to eq "String"
+    end
+  end
+
+  describe '#env_value' do
+    it 'returns the value of the named env. var. if set' do
+      option = OPTION_CLASS.new env_name: "USER"
+      expect(option.env_value).to eq ENV["USER"]
+    end
+
+    it 'returns nil if env_name is falsy' do
+      option = OPTION_CLASS.new env_name: false
+      expect(option.env_value).to be_nil
+    end
+  end
+
+  describe '#convert' do
+    it 'calls a convert_proc if present' do
+      option = OPTION_CLASS.new convert_proc: ->(value) { value * 3 }
+      expect(option.convert("*")).to eq "***"
+    end
+
+    it 'splits a string using commas if the type is Array' do
+      option = OPTION_CLASS.new type: Array
+      expect(option.convert("a,b")).to eq %w(a b)
+    end
+
+    it 'recognizes yes/no true/false for Boolean types' do
+      option = OPTION_CLASS.new({})
+      expect(option.convert("Yes")).to be true
+      expect(option.convert("TRUE")).to be true
+      expect(option.convert("yes")).to be true
+
+      expect(option.convert("no")).to be false
+      expect(option.convert("False")).to be false
+      expect(option.convert("NO")).to be false
+    end
+
+    it 'strips strings' do
+      option = OPTION_CLASS.new type: String
+      expect(option.convert(" abc  ")).to eq "abc"
+    end
+  end
+
+  describe '#valid?' do
+    it 'returns the result of a validate_proc if present' do
+      expected = false
+      option = OPTION_CLASS.new validate_proc: ->(value) { expected }
+      expect(option.valid?(:foo)).to eq expected
+    end
+
+    it 'checks #valid_values if non-nil' do
+      option = OPTION_CLASS.new valid_values_proc: ->() { %w(a b) }
+      expect(option.valid?("a")).to be true
+      expect(option.valid?("b")).to be true
+      expect(option.valid?("c")).to be false
+    end
+
+    it 'checks all values of an Array argument' do
+      option = OPTION_CLASS.new type: Array, valid_values_proc: ->() { %w(a b) }
+      expect(option.valid?(%w(a))).to be true
+      expect(option.valid?(%w(a b))).to be true
+      expect(option.valid?(%w(a b c))).to be false
+    end
+
+    it 'checks type conformance if type is non-nil' do
+      option = OPTION_CLASS.new type: Array
+      expect(option.valid?("a")).to be false
+      expect(option.valid?(%w(a))).to be true
+    end
+
+    it 'checks for Boolean values if type is nil' do
+      option = OPTION_CLASS.new({})
+      expect(option.valid?(true)).to be true
+      expect(option.valid?(false)).to be true
+      expect(option.valid?("foo")).to be false
+    end
+  end
+end

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -148,4 +148,22 @@ describe BranchIOCLI::Configuration::Option do
       expect(option.valid?("foo")).to be false
     end
   end
+
+  describe '#display_value' do
+    it 'returns yes and no when type is nil' do
+      option = OPTION_CLASS.new({})
+      expect(option.display_value(true)).to eq "yes"
+      expect(option.display_value(false)).to eq "no"
+    end
+
+    it 'converts to a string for other types' do
+      option = OPTION_CLASS.new(type: Integer)
+      expect(option.display_value(1)).to eq "1"
+    end
+
+    it 'returns "(none)" for nil' do
+      option = OPTION_CLASS.new(type: String)
+      expect(option.display_value(nil)).to eq "(none)"
+    end
+  end
 end

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -84,18 +84,6 @@ describe BranchIOCLI::Configuration::Option do
       option = OPTION_CLASS.new env_name: false
       expect(option.env_value).to be_nil
     end
-
-    it 'converts the value of env_name' do
-      ENV["FOO"] = "a,b,c"
-      option = OPTION_CLASS.new env_name: "FOO", type: Array
-      expect(option.env_value).to eq %w(a b c)
-    end
-
-    it 'returns nil unless env_name is valid' do
-      ENV["FOO"] = "a,b,c"
-      option = OPTION_CLASS.new env_name: "FOO", type: Array, validate_proc: ->(v) { false }
-      expect(option.env_value).to be_nil
-    end
   end
 
   describe '#convert' do

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -84,6 +84,12 @@ describe BranchIOCLI::Configuration::Option do
       option = OPTION_CLASS.new env_name: false
       expect(option.env_value).to be_nil
     end
+
+    it 'converts the value' do
+      ENV["FOO"] = "YES"
+      option = OPTION_CLASS.new env_name: "FOO"
+      expect(option.env_value).to be true
+    end
   end
 
   describe '#convert' do

--- a/spec/option_wrapper_spec.rb
+++ b/spec/option_wrapper_spec.rb
@@ -1,0 +1,23 @@
+describe BranchIOCLI::Configuration::OptionWrapper do
+  WRAPPER_CLASS = BranchIOCLI::Configuration::OptionWrapper
+  let (:options) do
+    [
+      BranchIOCLI::Configuration::Option.new(name: :foo, default_value: "bar")
+    ]
+  end
+
+  it 'returns the value of any valid key in a hash supplied to the initializer as a method' do
+    wrapper = WRAPPER_CLASS.new({ foo: "bar" }, options)
+
+    expect(wrapper.foo).to eq "bar"
+    expect do
+      wrapper.bar
+    end.to raise_error NoMethodError
+  end
+
+  it 'adds defaults if add_defaults is true' do
+    wrapper = WRAPPER_CLASS.new({}, options)
+
+    expect(wrapper.foo).to eq "bar"
+  end
+end

--- a/spec/option_wrapper_spec.rb
+++ b/spec/option_wrapper_spec.rb
@@ -2,8 +2,17 @@ describe BranchIOCLI::Configuration::OptionWrapper do
   WRAPPER_CLASS = BranchIOCLI::Configuration::OptionWrapper
   let (:options) do
     [
-      BranchIOCLI::Configuration::Option.new(name: :foo, default_value: "bar")
+      BranchIOCLI::Configuration::Option.new(
+        name: :foo,
+        default_value: "bar",
+        env_name: "FOO",
+        type: String
+      )
     ]
+  end
+
+  before :each do
+    ENV["FOO"] = nil
   end
 
   it 'returns the value of any valid key in a hash supplied to the initializer as a method' do
@@ -17,7 +26,18 @@ describe BranchIOCLI::Configuration::OptionWrapper do
 
   it 'adds defaults if add_defaults is true' do
     wrapper = WRAPPER_CLASS.new({}, options)
-
     expect(wrapper.foo).to eq "bar"
+  end
+
+  it 'consults any env_value before default_value' do
+    ENV["FOO"] = "y"
+    wrapper = WRAPPER_CLASS.new({}, options)
+    expect(wrapper.foo).to eq "y"
+  end
+
+  it 'does not consult the environment or default_value if add_defaults is false' do
+    ENV["FOO"] = "y"
+    wrapper = WRAPPER_CLASS.new({}, options, false)
+    expect(wrapper.foo).to be_nil
   end
 end


### PR DESCRIPTION
Using and expanding the new Option class, the setup command now prompts for confirmation of the configuration that was passed in and inferred, giving the user the opportunity to edit each parameter before continuing. This can be disabled using `--no-confirm`.