### PR TITLE
Empty strings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,8 @@ task :setup do
     validate: true,
     pod_repo_update: false,
     setting: true,
-    check_repo_changes: false
+    check_repo_changes: false,
+    confirm: false
   )
 end
 

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -61,8 +61,9 @@ module BranchIOCLI
 
         if type == Array
           value = value.split(",") if value.kind_of?(String)
-        elsif type == String
-          value = value.strip if value.kind_of?(String)
+        elsif type == String && value.kind_of?(String)
+          value = value.strip
+          value = nil if value.empty?
         elsif type.nil?
           value = true if value.kind_of?(String) && value =~ /^(true|yes)$/i
           value = false if value.kind_of?(String) && value =~ /^(false|no)$/i

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -118,6 +118,11 @@ describe BranchIOCLI::Configuration::Option do
       option = OPTION_CLASS.new type: String
       expect(option.convert(" abc  ")).to eq "abc"
     end
+
+    it 'returns nil for an empty string' do
+      option = OPTION_CLASS.new type: String
+      expect(option.convert("")).to be_nil
+    end
   end
 
   describe '#valid?' do


### PR DESCRIPTION
`Option#convert` now returns nil for an empty string. Also added `confirm: false` to the Rakefile for the setup command.