### PR TITLE
Confirm vs agree

### DIFF
--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -1,8 +1,10 @@
-require "branch_io_cli/helper/methods"
+require "branch_io_cli/helper"
 
 module BranchIOCLI
   module Command
     class SetupCommand < Command
+      include Helper::Methods
+
       def initialize(options)
         super
         @keys = config.keys

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -2,8 +2,6 @@ require "cocoapods-core"
 require "pathname"
 require "xcodeproj"
 
-require "branch_io_cli/helper/methods"
-
 module BranchIOCLI
   module Configuration
     # rubocop: disable Metrics/ClassLength
@@ -395,11 +393,13 @@ EOF
 
       # Prompt the user to confirm the configuration or edit.
       def confirm_with_user
-        confirmed = agree "Is this OK (Y/n)? "
-        return unless confirmed == false
+        @util = Helper::Util.new
+
+        confirmed = @util.confirm "Is this OK? ", true
+        return if confirmed
 
         loop do
-          clear
+          @util.clear
 
           say "<%= color('The following options may be adjusted before continuing.', BOLD) %>"
           choice = choose do |menu|
@@ -413,7 +413,7 @@ EOF
             menu.prompt = "What would you like to do?"
           end
 
-          clear
+          @util.clear
 
           selected_sym = choice.sub(/:.*$/, '').gsub(/\s/, '_').downcase.to_sym
 
@@ -456,7 +456,7 @@ EOF
           end
           new_value = ask "Please enter one or more of the above, separated by commas: ", Array
         elsif option.type.nil?
-          new_value = agree "#{option.name.to_s.gsub(/_/, ' ').capitalize} (y/n)? "
+          new_value = @util.confirm "#{option.name.to_s.gsub(/_/, ' ').capitalize}? ", value
         else
           new_value = ask "Please enter a new value for #{option.name.to_s.gsub(/_/, ' ').capitalize}: ", option.type
         end

--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -393,13 +393,11 @@ EOF
 
       # Prompt the user to confirm the configuration or edit.
       def confirm_with_user
-        @util = Helper::Util.new
-
-        confirmed = @util.confirm "Is this OK? ", true
+        confirmed = Helper::Util.confirm "Is this OK? ", true
         return if confirmed
 
         loop do
-          @util.clear
+          Helper::Util.clear
 
           say "<%= color('The following options may be adjusted before continuing.', BOLD) %>"
           choice = choose do |menu|
@@ -413,7 +411,7 @@ EOF
             menu.prompt = "What would you like to do?"
           end
 
-          @util.clear
+          Helper::Util.clear
 
           selected_sym = choice.sub(/:.*$/, '').gsub(/\s/, '_').downcase.to_sym
 
@@ -456,7 +454,7 @@ EOF
           end
           new_value = ask "Please enter one or more of the above, separated by commas: ", Array
         elsif option.type.nil?
-          new_value = @util.confirm "#{option.name.to_s.gsub(/_/, ' ').capitalize}? ", value
+          new_value = Helper::Util.confirm "#{option.name.to_s.gsub(/_/, ' ').capitalize}? ", value
         else
           new_value = ask "Please enter a new value for #{option.name.to_s.gsub(/_/, ' ').capitalize}: ", option.type
         end

--- a/lib/branch_io_cli/configuration/option.rb
+++ b/lib/branch_io_cli/configuration/option.rb
@@ -65,8 +65,8 @@ module BranchIOCLI
           value = value.strip
           value = nil if value.empty?
         elsif type.nil?
-          value = true if value.kind_of?(String) && value =~ /^(true|yes)$/i
-          value = false if value.kind_of?(String) && value =~ /^(false|no)$/i
+          value = true if value.kind_of?(String) && value =~ /^[ty]/i
+          value = false if value.kind_of?(String) && value =~ /^[fn]/i
         end
 
         value

--- a/lib/branch_io_cli/helper.rb
+++ b/lib/branch_io_cli/helper.rb
@@ -1,3 +1,5 @@
 require "branch_io_cli/helper/branch_helper"
+require "branch_io_cli/helper/methods"
 require "branch_io_cli/helper/patch_helper"
 require "branch_io_cli/helper/report_helper"
+require "branch_io_cli/helper/util"

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -15,6 +15,8 @@ require "branch_io_cli/helper/methods"
 module BranchIOCLI
   module Helper
     module IOSHelper
+      include Methods
+
       APPLINKS = "applinks"
       ASSOCIATED_DOMAINS = "com.apple.developer.associated-domains"
       CODE_SIGN_ENTITLEMENTS = "CODE_SIGN_ENTITLEMENTS"
@@ -713,8 +715,8 @@ EOF
           exit(-1)
         end
 
-        install = agree "'pod' command not available in PATH. Install cocoapods (may require a sudo password) (Y/n)? "
-        if install == false
+        install = confirm "'pod' command not available in PATH. Install cocoapods (may require a sudo password)?", true
+        unless install
           say "Please install cocoapods or use --no-add-sdk to continue."
           exit(-1)
         end
@@ -740,8 +742,8 @@ EOF
           exit(-1)
         end
 
-        install = agree "'carthage' command not available in PATH. Use Homebrew to install carthage (Y/n)? "
-        if install == false
+        install = confirm "'carthage' command not available in PATH. Use Homebrew to install carthage?", true
+        unless install
           say "Please install carthage or use --no-add-sdk to continue."
           exit(-1)
         end
@@ -761,8 +763,8 @@ EOF
           exit(-1)
         end
 
-        install = agree "'git' command not available in PATH. Install Xcode command-line tools (requires password) (Y/n)? "
-        if install == false
+        install = confirm "'git' command not available in PATH. Install Xcode command-line tools (requires password)?", true
+        unless install
           say "Please install Xcode command tools or leave out the --commit option to continue."
           exit(-1)
         end

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -30,8 +30,14 @@ module BranchIOCLI
       def clear
         say "\e[2J\e[H"
       end
+
+      # Ask a yes/no question with a default
+      def confirm(question, default_value)
+        yn_opts = default_value ? "Y/n" : "y/N"
+        value = ask "#{question} (#{yn_opts}) ", nil
+        return default_value if value.nil?
+        value
+      end
     end
   end
 end
-
-include BranchIOCLI::Helper::Methods

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -35,7 +35,12 @@ module BranchIOCLI
       def confirm(question, default_value)
         yn_opts = default_value ? "Y/n" : "y/N"
         value = ask "#{question} (#{yn_opts}) ", nil
-        return default_value if value.nil?
+
+        # Convert to true/false
+        dummy_option = Configuration::Option.new({})
+        value = dummy_option.convert(value)
+
+        return default_value if value.nil? || value.kind_of?(String)
         value
       end
     end

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -6,6 +6,8 @@ module BranchIOCLI
   module Helper
     class ReportHelper
       class << self
+        include Methods
+
         def report_imports
           report = "Branch imports:\n"
           config.branch_imports.each_key do |path|
@@ -215,9 +217,10 @@ module BranchIOCLI
           return unless config.pod_install_required?
           # Only if a Podfile is detected/supplied at the command line.
           say "pod install required in order to build."
-          install = agree %{Run "pod install" now (Y/n)? }
-          if install == false
-            say %{Please run "pod install" or "pod update" first in order to continue.}
+          install = confirm 'Run "pod install" now?', true
+
+          unless install
+            say 'Please run "pod install" or "pod update" first in order to continue.'
             exit(-1)
           end
 

--- a/lib/branch_io_cli/helper/util.rb
+++ b/lib/branch_io_cli/helper/util.rb
@@ -1,0 +1,7 @@
+module BranchIOCLI
+  module Helper
+    class Util
+      include Methods
+    end
+  end
+end

--- a/lib/branch_io_cli/helper/util.rb
+++ b/lib/branch_io_cli/helper/util.rb
@@ -1,7 +1,7 @@
 module BranchIOCLI
   module Helper
     class Util
-      include Methods
+      extend Methods
     end
   end
 end


### PR DESCRIPTION
Added a `#confirm` method to the `Methods` module to improve on Highline's `#agree`.

Until a lot of things can be refactored, having `Methods` auto-included is troublesome. Added `Util` class that just mixes in `Methods` for places where including the module is troublesome.