### PR TITLE
Resolve against Xcode settings

### DIFF
--- a/lib/branch_io_cli/helper/xcodeproj_ext.rb
+++ b/lib/branch_io_cli/helper/xcodeproj_ext.rb
@@ -72,7 +72,13 @@ module Xcodeproj
             setting_value = resolved_build_setting(setting_name, false)[configuration]
           end
 
-          return if setting_value.nil?
+          # TODO: What is the correct resolution order here? Which overrides which in
+          # Xcode?
+          if setting_value.nil? && defined?(BranchIOCLI::Configuration::XcodeSettings)
+            setting_value = BranchIOCLI::Configuration::XcodeSettings[configuration][setting_name]
+          end
+
+          return nil if setting_value.nil?
 
           expand_build_settings setting_value, configuration
         end

--- a/spec/xcodeproj_ext_spec.rb
+++ b/spec/xcodeproj_ext_spec.rb
@@ -29,10 +29,10 @@ describe 'Xcodeproj extensions' do
       expect(target.expanded_build_setting("SETTING_WITH_NESTED_VALUE", "Release")).to eq "value"
     end
 
-    it "expands the first component of a path as a setting if all-caps" do
-      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "SETTING_VALUE/file.txt" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true) { { "Release" => "value" } }
-      expect(target.expanded_build_setting("SETTING_WITH_NESTED_VALUE", "Release")).to eq "value/file.txt"
+    it "expands any component of a path as a setting if all-caps" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUE", true) { { "Release" => "SETTING_VALUE/SETTING_VALUE/file.txt" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE", true).at_least(:once) { { "Release" => "value" } }
+      expect(target.expanded_build_setting("SETTING_WITH_NESTED_VALUE", "Release")).to eq "value/value/file.txt"
     end
 
     it "resolves without an xcconfig if the xcconfig is not found" do

--- a/spec/xcodeproj_ext_spec.rb
+++ b/spec/xcodeproj_ext_spec.rb
@@ -44,6 +44,7 @@ describe 'Xcodeproj extensions' do
 
     it "returns nil if the setting is not present" do
       expect(target).to receive(:resolved_build_setting).with("NONEXISTENT_SETTING", true) { { "Release" => nil } }
+      expect(BranchIOCLI::Configuration::XcodeSettings).to receive(:[]).with("Release") { {} }
       expect(target.expanded_build_setting("NONEXISTENT_SETTING", "Release")).to be_nil
     end
 
@@ -91,6 +92,7 @@ describe 'Xcodeproj extensions' do
       expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_BOGUS_VALUE", true) { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1", true) { { "Release" => nil } }
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2", true) { { "Release" => "value2" } }
+      expect(BranchIOCLI::Configuration::XcodeSettings).to receive(:[]).with("Release") { {} }
       expect(target.expanded_build_setting("SETTING_WITH_BOGUS_VALUE", "Release")).to eq "$(SETTING_VALUE1).value2"
     end
 
@@ -110,6 +112,12 @@ describe 'Xcodeproj extensions' do
       expect(target).to receive(:resolved_build_setting).with("PRODUCT_NAME", true) { { "Release" => "My .@*&'\\\"+%_App" } }
       expect(target).to receive(:resolved_build_setting).with("PRODUCT_BUNDLE_IDENTIFIER", true) { { "Release" => "com.example.$(PRODUCT_NAME:rfc1034identifier)" } }
       expect(target.expanded_build_setting("PRODUCT_BUNDLE_IDENTIFIER", "Release")).to eq "com.example.My-----------App"
+    end
+
+    it "expands against Xcode settings when setting not found for target" do
+      expect(target).to receive(:resolved_build_setting).with("PROJECT_NAME", true) { { "Release" => nil } }
+      expect(BranchIOCLI::Configuration::XcodeSettings).to receive(:[]).with("Release") { { "PROJECT_NAME" => "MyProject" } }
+      expect(target.expanded_build_setting("PROJECT_NAME", "Release")).to eq "MyProject"
     end
   end
 end


### PR DESCRIPTION
When not found in the project or target, `PBXNativeTarget#expanded_build_setting` will also consult Xcode settings, if present.