### PR TITLE
Fix setup and validate commands

### DIFF
--- a/lib/branch_io_cli/configuration/configuration.rb
+++ b/lib/branch_io_cli/configuration/configuration.rb
@@ -61,10 +61,12 @@ module BranchIOCLI
       attr_reader :workspace
       attr_reader :workspace_path
       attr_reader :pod_repo_update
+      attr_reader :sdk
 
       def initialize(options)
         @options = options
         @pod_repo_update = options.pod_repo_update if self.class.available_options.map(&:name).include?(:pod_repo_update)
+        @sdk = "iphonesimulator" # to load Xcode build settings for commands without a --sdk option
 
         Configuration.current = self
 

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -29,7 +29,13 @@ module BranchIOCLI
 
       def initialize(configuration)
         @configuration = configuration
-        load_settings_from_xcode
+
+        if config.respond_to?(:sdk)
+          # For now, limit this to the report command
+          load_settings_from_xcode
+        else
+          @xcode_settings = {}
+        end
       end
 
       def valid?

--- a/lib/branch_io_cli/configuration/xcode_settings.rb
+++ b/lib/branch_io_cli/configuration/xcode_settings.rb
@@ -30,12 +30,7 @@ module BranchIOCLI
       def initialize(configuration)
         @configuration = configuration
 
-        if config.respond_to?(:sdk)
-          # For now, limit this to the report command
-          load_settings_from_xcode
-        else
-          @xcode_settings = {}
-        end
+        load_settings_from_xcode
       end
 
       def valid?

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -168,11 +168,11 @@ module BranchIOCLI
               report += "  Branch key(s) #{annotation}:\n"
               if branch_key.kind_of? Hash
                 branch_key.each_key do |key|
-                  resolved_key = helper.expand_build_settings branch_key[key], config.target, configuration
+                  resolved_key = config.target.expand_build_settings branch_key[key], configuration
                   report += "   #{key.capitalize}: #{resolved_key}\n"
                 end
               elsif branch_key
-                resolved_key = helper.expand_build_settings branch_key, config.target, configuration
+                resolved_key = config.target.expand_build_settings branch_key, configuration
                 report += "   #{resolved_key}\n"
               else
                 report += "   (none found)\n"


### PR DESCRIPTION
Now that `XcodeSettings` is consulted when resolving build settings, the SDK needs to be specified for all commands. For now, default it to `iphonesimulator` for the setup and validate commands, in order to load things like `PROJECT_DIR`. The other commands may also need a `--sdk` option eventually.

Also eliminated the last call to `helper.expanded_build_setting`, which resulted in Branch keys not being correctly reported.