### PR TITLE
Get rid of extra lines in patched source code.

### DIFF
--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'cocoapods-core'
   spec.add_dependency 'commander'
-  spec.add_dependency 'pattern_patch', '>= 0.5.3'
+  spec.add_dependency 'pattern_patch', '>= 0.5.4'
   spec.add_dependency 'plist'
   spec.add_dependency 'rubyzip'
   spec.add_dependency 'xcodeproj'

--- a/lib/branch_io_cli/helper/patch_helper.rb
+++ b/lib/branch_io_cli/helper/patch_helper.rb
@@ -7,7 +7,8 @@ module BranchIOCLI
       extend PatternPatch::Methods
 
       # Set the patch_dir for PatternPatch
-      @patch_dir = File.expand_path(File.join('..', '..', '..', 'assets', 'patches'), __FILE__)
+      self.patch_dir = File.expand_path(File.join('..', '..', '..', 'assets', 'patches'), __FILE__)
+      self.trim_mode = "<>"
 
       class << self
         def config


### PR DESCRIPTION
This uses pattern_patch 0.5.4 to pass a default trim mode to ERb. This results in lines like

```ERb
<% if use_conditional_test_key? %>
```

to be stripped out instead of remaining blank.