### PR TITLE
Associated domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,15 +208,17 @@ Only app targets are supported for this command. By default, it will validate th
 If your project has multiple app targets, specify the `--target` option to validate other
 targets.
 
-All parameters are optional. If `--domains` is specified, the list of Universal Link domains in
-the Associated Domains entitlement must exactly match this list, without regard to order. If
-no `--domains` are provided, validation passes if at least one Universal Link domain is
-configured and passes validation, and no Universal Link domain is present that does not pass
-validation.
-
 By default, all build configurations in the project are validated. To validate a different list
-of configurations, including a single configuration, specify the `--configurations`
-option.
+of configurations, including a single configuration, specify the `--configurations` option.
+
+If `--domains` is specified, the list of Universal Link domains in the Associated
+Domains entitlement must exactly match this list, without regard to order, for all
+configurations under validation. If no `--domains` are provided, validation passes
+if at least one Universal Link domain is configured for each configuration and passes
+validation, and no Universal Link domain is present in anyconfiguration that does not
+pass validation.
+
+All parameters are optional.
 
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ no `--domains` are provided, validation passes if at least one Universal Link do
 configured and passes validation, and no Universal Link domain is present that does not pass
 validation.
 
+By default, all build configurations in the project are validated. To validate a different list
+of configurations, including a single configuration, specify the `--configurations`
+option.
+
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ See https://github.com/BranchMetrics/branch_io_cli#validate-command for more inf
 |-D, --domains example.com,www.example.com|Comma-separated list of domains to validate (Branch domains or non-Branch domains) (default: [])|BRANCH_DOMAINS|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|BRANCH_XCODEPROJ|
 |--target MyAppTarget|Name of a target to validate in the Xcode project|BRANCH_TARGET|
+|--configurations Debug,Release|Comma-separated list of configurations to validate (default: all)|BRANCH_CONFIGURATIONS|
 
 
 

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -17,7 +17,7 @@ _branch_io_complete()
 
     report_opts="--workspace --xcodeproj --scheme --target --configuration --sdk --podfile --cartfile --no-clean -H --header-only --no-pod-repo-update -o --out"
 
-    validate_opts="-D --domains --xcodeproj --target"
+    validate_opts="-D --domains --xcodeproj --target --configurations"
 
 
     if [[ ${cur} == -* ]] ; then

--- a/lib/assets/templates/validate_description.erb
+++ b/lib/assets/templates/validate_description.erb
@@ -9,14 +9,16 @@ Only app targets are supported for this command. By default, it will validate th
 If your project has multiple app targets, specify the <%= option :target %> option to validate other
 targets.
 
-All parameters are optional. If <%= option :domains %> is specified, the list of Universal Link domains in
-the Associated Domains entitlement must exactly match this list, without regard to order. If
-no <%= option :domains %> are provided, validation passes if at least one Universal Link domain is
-configured and passes validation, and no Universal Link domain is present that does not pass
-validation.
-
 By default, all build configurations in the project are validated. To validate a different list
-of configurations, including a single configuration, specify the <%= option :configurations %>
-option.
+of configurations, including a single configuration, specify the <%= option :configurations %> option.
+
+If <%= option :domains %> is specified, the list of Universal Link domains in the Associated
+Domains entitlement must exactly match this list, without regard to order, for all
+configurations under validation. If no <%= option :domains %> are provided, validation passes
+if at least one Universal Link domain is configured for each configuration and passes
+validation, and no Universal Link domain is present in anyconfiguration that does not
+pass validation.
+
+All parameters are optional.
 
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.

--- a/lib/assets/templates/validate_description.erb
+++ b/lib/assets/templates/validate_description.erb
@@ -15,4 +15,8 @@ no <%= option :domains %> are provided, validation passes if at least one Univer
 configured and passes validation, and no Universal Link domain is present that does not pass
 validation.
 
+By default, all build configurations in the project are validated. To validate a different list
+of configurations, including a single configuration, specify the <%= option :configurations %>
+option.
+
 See https://github.com/BranchMetrics/branch_io_cli#validate-command for more information.

--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -45,8 +45,12 @@ module BranchIOCLI
         helper.add_branch_universal_link_domains_to_info_plist @domains if is_app_target
         helper.ensure_uri_scheme_in_info_plist if is_app_target # does nothing if already present
 
-        new_path = helper.add_universal_links_to_project @domains, false if is_app_target
-        sh ["git", "add", new_path] if config.commit && new_path
+        if is_app_target
+          config.xcodeproj.build_configurations.each do |c|
+            new_path = helper.add_universal_links_to_project @domains, false, c.name
+            sh ["git", "add", new_path] if config.commit && new_path
+          end
+        end
 
         config_helper.target.add_system_frameworks config.frameworks unless config.frameworks.nil? || config.frameworks.empty?
 

--- a/lib/branch_io_cli/command/validate_command.rb
+++ b/lib/branch_io_cli/command/validate_command.rb
@@ -7,7 +7,8 @@ module BranchIOCLI
         configurations = config.configurations || config.xcodeproj.build_configurations.map(&:name)
 
         configurations.each do |configuration|
-          say "Validating #{configuration} configuration"
+          message = "Validating #{configuration} configuration"
+          say "\n<%= color('#{message}', [BOLD, CYAN]) %>\n\n"
 
           config_valid = true
 
@@ -15,9 +16,9 @@ module BranchIOCLI
             domains_valid = helper.validate_project_domains(config.domains, configuration)
 
             if domains_valid
-              say " Project domains match :domains parameter: ✅"
+              say "Project domains match :domains parameter: ✅"
             else
-              say " Project domains do not match specified :domains"
+              say "Project domains do not match specified :domains"
               helper.errors.each { |error| say "  #{error}" }
             end
 

--- a/lib/branch_io_cli/configuration/validate_configuration.rb
+++ b/lib/branch_io_cli/configuration/validate_configuration.rb
@@ -31,6 +31,12 @@ module BranchIOCLI
               description: "Name of a target to validate in the Xcode project",
               type: String,
               example: "MyAppTarget"
+            ),
+            Option.new(
+              name: :configurations,
+              description: "Comma-separated list of configurations to validate (default: all)",
+              type: Array,
+              example: "Debug,Release"
             )
           ]
         end

--- a/lib/branch_io_cli/configuration/validate_configuration.rb
+++ b/lib/branch_io_cli/configuration/validate_configuration.rb
@@ -58,6 +58,7 @@ module BranchIOCLI
 <%= color('Xcode project:', BOLD) %> #{xcodeproj_path}
 <%= color('Target:', BOLD) %> #{target.name}
 <%= color('Domains:', BOLD) %> #{domains || '(none)'}
+<%= color('Configurations:', BOLD) %> #{(configurations || xcodeproj.build_configurations.map(&:name)).join(',')}
 EOF
       end
     end

--- a/lib/branch_io_cli/helper/ios_helper.rb
+++ b/lib/branch_io_cli/helper/ios_helper.rb
@@ -392,7 +392,10 @@ module BranchIOCLI
         entitlements = File.open(entitlements_path) { |f| Plist.parse_xml f }
         raise "Failed to parse entitlements file #{entitlements_path}" if entitlements.nil?
 
-        entitlements[ASSOCIATED_DOMAINS].select { |d| d =~ /^applinks:/ }.map { |d| d.sub(/^applinks:/, "") }
+        associated_domains = entitlements[ASSOCIATED_DOMAINS]
+        return [] if associated_domains.nil?
+
+        associated_domains.select { |d| d =~ /^applinks:/ }.map { |d| d.sub(/^applinks:/, "") }
       end
 
       def add_cocoapods(options)

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -61,7 +61,6 @@ module BranchIOCLI
 
           bundle_identifier = config.target.expanded_build_setting "PRODUCT_BUNDLE_IDENTIFIER", configuration
           dev_team = config.target.expanded_build_setting "DEVELOPMENT_TEAM", configuration
-          entitlements_path = config.target.expanded_build_setting "CODE_SIGN_ENTITLEMENTS", configuration
 
           header += "\nTarget #{config.target.name}:\n"
           header += " Bundle identifier: #{bundle_identifier || '(none)'}\n"
@@ -76,7 +75,10 @@ module BranchIOCLI
             header += "  #{c}: #{config.target.expanded_build_setting 'INFOPLIST_FILE', c}\n"
           end
 
-          header += " Entitlements file: #{config.relative_path(entitlements_path) || '(none)'}\n"
+          header += " Entitlements file\n"
+          configurations.each do |c|
+            header += "  #{c}: #{config.target.expanded_build_setting 'CODE_SIGN_ENTITLEMENTS', c}\n"
+          end
 
           if config.podfile_path
             begin

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -198,12 +198,13 @@ module BranchIOCLI
 
           unless config.target.extension_target_type?
             begin
-              # This isn't likely to vary by configuration, so just report for one, either
-              # whatever was passed or Release.
-              domains = helper.domains_from_project config.configuration || config.configurations_from_scheme.first
-              report += " Universal Link domains (entitlements):\n"
-              domains.each do |domain|
-                report += "  #{domain}\n"
+              configurations = config.configuration ? [config.configuration] : config.configurations_from_scheme
+              configurations.each do |configuration|
+                domains = helper.domains_from_project configuration
+                report += " Universal Link domains (entitlements:#{configuration}):\n"
+                domains.each do |domain|
+                  report += "  #{domain}\n"
+                end
               end
             rescue StandardError => e
               report += " (Failed to get Universal Link domains from entitlements file: #{e.message})\n"


### PR DESCRIPTION
Improved handling of Associated Domains entitlement.

Better handling for the case where a project has an entitlements file with no associated-domains entitlement.

Added support for entitlements per configuration to all commands.

- Setup: All domains inserted into the entitlements file for each configuration in the project. Duplicates are avoided in case the same file is processed for multiple configurations.
- Validate: By default, all configurations are validated. A `--configurations` option was introduced to override.
- Report: Entitlements files and domains reported for all configurations