### PR TITLE
Carthage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |--target MyAppTarget|Name of a target to modify in the Xcode project|BRANCH_TARGET|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|BRANCH_PODFILE|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|BRANCH_CARTFILE|
-|--carthage-command update --no-use-binaries|Command to run when installing from Carthage (default: bootstrap --platform ios)|BRANCH_CARTHAGE_COMMAND|
+|--carthage-command bootstrap --no-use-binaries|Command to run when installing from Carthage (default: update --platform ios)|BRANCH_CARTHAGE_COMMAND|
 |--frameworks AdSupport,CoreSpotlight,SafariServices|Comma-separated list of system frameworks to add to the project|BRANCH_FRAMEWORKS|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|BRANCH_POD_REPO_UPDATE|
 |--[no-]validate|Validate Universal Link configuration (default: yes)|BRANCH_VALIDATE|
@@ -194,10 +194,10 @@ br setup --no-pod-repo-update
 ```
 
 
-##### Install using carthage update
+##### Install using carthage bootstrap
 
 ```bash
-br setup --carthage-command "update --no-use-binaries"
+br setup --carthage-command "bootstrap --no-use-binaries"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |--target MyAppTarget|Name of a target to modify in the Xcode project|BRANCH_TARGET|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|BRANCH_PODFILE|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|BRANCH_CARTFILE|
-|--carthage-command update --platform ios|Command to run when installing from Carthage (default: bootstrap --platform ios)|BRANCH_CARTHAGE_COMMAND|
+|--carthage-command update --no-use-binaries|Command to run when installing from Carthage (default: bootstrap --platform ios)|BRANCH_CARTHAGE_COMMAND|
 |--frameworks AdSupport,CoreSpotlight,SafariServices|Comma-separated list of system frameworks to add to the project|BRANCH_FRAMEWORKS|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|BRANCH_POD_REPO_UPDATE|
 |--[no-]validate|Validate Universal Link configuration (default: yes)|BRANCH_VALIDATE|

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |--target MyAppTarget|Name of a target to modify in the Xcode project|BRANCH_TARGET|
 |--podfile /path/to/Podfile|Path to the Podfile for the project|BRANCH_PODFILE|
 |--cartfile /path/to/Cartfile|Path to the Cartfile for the project|BRANCH_CARTFILE|
-|--carthage-command <command>|Command to run when installing from Carthage (default: update --platform ios)|BRANCH_CARTHAGE_COMMAND|
+|--carthage-command update --platform ios|Command to run when installing from Carthage (default: bootstrap --platform ios)|BRANCH_CARTHAGE_COMMAND|
 |--frameworks AdSupport,CoreSpotlight,SafariServices|Comma-separated list of system frameworks to add to the project|BRANCH_FRAMEWORKS|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|BRANCH_POD_REPO_UPDATE|
 |--[no-]validate|Validate Universal Link configuration (default: yes)|BRANCH_VALIDATE|
@@ -194,10 +194,10 @@ br setup --no-pod-repo-update
 ```
 
 
-##### Install using carthage bootstrap
+##### Install using carthage update
 
 ```bash
-br setup --carthage-command "bootstrap --no-use-binaries"
+br setup --carthage-command "update --no-use-binaries"
 ```
 
 
@@ -285,6 +285,7 @@ building.
 |-H, --[no-]header-only|Write a report header to standard output and exit (default: no)|BRANCH_HEADER_ONLY|
 |--[no-]pod-repo-update|Update the local podspec repo before installing (default: yes)|BRANCH_POD_REPO_UPDATE|
 |-o, --out ./report.txt|Report output path (default: ./report.txt)|BRANCH_REPORT_PATH|
+|--[no-]confirm|Confirm before running certain commands (default: yes)|BRANCH_CONFIRM|
 
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ end
 
 desc "Perform a full build of all examples in the repo"
 task "report:full" do
-  Rake::Task["branch:report"].invoke all_projects, pod_repo_update: false
+  Rake::Task["branch:report"].invoke all_projects, pod_repo_update: false, confirm: false
 end
 
 #

--- a/lib/assets/completions/completion.bash
+++ b/lib/assets/completions/completion.bash
@@ -15,7 +15,7 @@ _branch_io_complete()
 
     setup_opts="-L --live-key -T --test-key -D --domains --app-link-subdomain -U --uri-scheme -s --setting --test-configurations --xcodeproj --target --podfile --cartfile --carthage-command --frameworks --no-pod-repo-update --no-validate --force --no-add-sdk --no-patch-source --commit --no-confirm"
 
-    report_opts="--workspace --xcodeproj --scheme --target --configuration --sdk --podfile --cartfile --no-clean -H --header-only --no-pod-repo-update -o --out"
+    report_opts="--workspace --xcodeproj --scheme --target --configuration --sdk --podfile --cartfile --no-clean -H --header-only --no-pod-repo-update -o --out --no-confirm"
 
     validate_opts="-D --domains --xcodeproj --target --configurations"
 

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -38,6 +38,7 @@ module BranchIOCLI
         report.write "#{report_helper.report_header}\n"
 
         report_helper.pod_install_if_required report
+        report_helper.carthage_bootstrap_if_required report
 
         # run xcodebuild -list
         report.sh(*report_helper.base_xcodebuild_cmd, "-list")

--- a/lib/branch_io_cli/configuration/report_options.rb
+++ b/lib/branch_io_cli/configuration/report_options.rb
@@ -77,6 +77,12 @@ module BranchIOCLI
               example: "./report.txt",
               type: String,
               env_name: "BRANCH_REPORT_PATH"
+            ),
+            Option.new(
+              name: :confirm,
+              description: "Confirm before running certain commands",
+              default_value: true,
+              skip_confirmation: true
             )
           ]
         end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -12,7 +12,7 @@ module BranchIOCLI
             "Use both live and test keys" => "br setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link",
             "Use custom or non-Branch domains" => "br setup -D myapp.app.link,example.com,www.example.com",
             "Avoid pod repo update" => "br setup --no-pod-repo-update",
-            "Install using carthage update" => "br setup --carthage-command \"update --no-use-binaries\""
+            "Install using carthage bootstrap" => "br setup --carthage-command \"bootstrap --no-use-binaries\""
           }
         end
       end

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -12,7 +12,7 @@ module BranchIOCLI
             "Use both live and test keys" => "br setup -L key_live_xxxx -T key_test_yyyy -D myapp.app.link",
             "Use custom or non-Branch domains" => "br setup -D myapp.app.link,example.com,www.example.com",
             "Avoid pod repo update" => "br setup --no-pod-repo-update",
-            "Install using carthage bootstrap" => "br setup --carthage-command \"bootstrap --no-use-binaries\""
+            "Install using carthage update" => "br setup --carthage-command \"update --no-use-binaries\""
           }
         end
       end

--- a/lib/branch_io_cli/configuration/setup_options.rb
+++ b/lib/branch_io_cli/configuration/setup_options.rb
@@ -95,7 +95,7 @@ module BranchIOCLI
             Option.new(
               name: :carthage_command,
               description: "Command to run when installing from Carthage",
-              example: "update --platform ios",
+              example: "update --no-use-binaries",
               type: String,
               default_value: "bootstrap --platform ios"
             ),

--- a/lib/branch_io_cli/configuration/setup_options.rb
+++ b/lib/branch_io_cli/configuration/setup_options.rb
@@ -95,9 +95,9 @@ module BranchIOCLI
             Option.new(
               name: :carthage_command,
               description: "Command to run when installing from Carthage",
-              example: "<command>",
+              example: "update --platform ios",
               type: String,
-              default_value: "update --platform ios"
+              default_value: "bootstrap --platform ios"
             ),
             Option.new(
               name: :frameworks,

--- a/lib/branch_io_cli/configuration/setup_options.rb
+++ b/lib/branch_io_cli/configuration/setup_options.rb
@@ -95,9 +95,9 @@ module BranchIOCLI
             Option.new(
               name: :carthage_command,
               description: "Command to run when installing from Carthage",
-              example: "update --no-use-binaries",
+              example: "bootstrap --no-use-binaries",
               type: String,
-              default_value: "bootstrap --platform ios"
+              default_value: "update --platform ios"
             ),
             Option.new(
               name: :frameworks,

--- a/lib/branch_io_cli/helper/methods.rb
+++ b/lib/branch_io_cli/helper/methods.rb
@@ -3,8 +3,8 @@ module BranchIOCLI
     class CommandError < RuntimeError
       attr_reader :status
       def initialize(args)
-        @args = args.first
-        @status = args.second
+        @args = args[0]
+        @status = args[1]
         super message
       end
 

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -255,9 +255,9 @@ some cases. If that happens, please rerun without --no-pod-repo-update or run
           return unless config.cartfile_path
           return if Dir.exist?(File.join(File.dirname(config.cartfile_path), "Carthage", "Build", "iOS"))
 
-          say "carthage bootstrap required in order to build."
+          say "carthage checkout required in order to build."
           if config.confirm
-            install = confirm 'Run "carthage bootstrap --platform ios" now?', true
+            install = confirm 'Run "carthage checkout && carthage build --platform ios" now?', true
 
             unless install
               say 'Please build your Carthage dependencies first in order to continue.'
@@ -267,7 +267,7 @@ some cases. If that happens, please rerun without --no-pod-repo-update or run
 
           ToolHelper.verify_carthage
 
-          install_command = "carthage bootstrap --platform ios"
+          install_command = "carthage checkout && carthage build --platform ios"
 
           say "Running #{install_command.inspect}"
           if report.sh(install_command).success?

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -217,12 +217,15 @@ module BranchIOCLI
         def pod_install_if_required(report)
           return unless config.pod_install_required?
           # Only if a Podfile is detected/supplied at the command line.
-          say "pod install required in order to build."
-          install = confirm 'Run "pod install" now?', true
 
-          unless install
-            say 'Please run "pod install" or "pod update" first in order to continue.'
-            exit(-1)
+          say "pod install required in order to build."
+          if config.confirm
+            install = confirm 'Run "pod install" now?', true
+
+            unless install
+              say 'Please run "pod install" or "pod update" first in order to continue.'
+              exit(-1)
+            end
           end
 
           ToolHelper.verify_cocoapods
@@ -243,7 +246,34 @@ some cases. If that happens, please rerun without --no-pod-repo-update or run
           if report.sh(install_command).success?
             say "Done ✅"
           else
-            say "pod install failed. See report for details."
+            say "#{install_command.inspect} failed. See report for details."
+            exit(-1)
+          end
+        end
+
+        def carthage_bootstrap_if_required(report)
+          return unless config.cartfile_path
+          return if Dir.exist?(File.join(File.dirname(config.cartfile_path), "Carthage", "Build", "iOS"))
+
+          say "carthage bootstrap required in order to build."
+          if config.confirm
+            install = confirm 'Run "carthage bootstrap --platform ios" now?', true
+
+            unless install
+              say 'Please build your Carthage dependencies first in order to continue.'
+              exit(-1)
+            end
+          end
+
+          ToolHelper.verify_carthage
+
+          install_command = "carthage bootstrap --platform ios"
+
+          say "Running #{install_command.inspect}"
+          if report.sh(install_command).success?
+            say "Done ✅"
+          else
+            say "#{install_command.inspect} failed. See report for details."
             exit(-1)
           end
         end

--- a/lib/branch_io_cli/helper/tool_helper.rb
+++ b/lib/branch_io_cli/helper/tool_helper.rb
@@ -220,7 +220,9 @@ github "BranchMetrics/ios-branch-deep-linking"
           return false unless PatchHelper.patch_cartfile cartfile_path
 
           # 2. carthage update
-          sh "carthage #{options.carthage_command} ios-branch-deep-linking", chdir: File.dirname(config.cartfile_path)
+          cmd = "carthage #{options.carthage_command}"
+          cmd << " ios-branch-deep-linking" if options.carthage_command =~ /^(update|build)/
+          sh cmd, chdir: File.dirname(config.cartfile_path)
 
           # 3. Add Cartfile and Cartfile.resolved to commit (in case :commit param specified)
           helper.add_change cartfile_path

--- a/lib/branch_io_cli/helper/tool_helper.rb
+++ b/lib/branch_io_cli/helper/tool_helper.rb
@@ -219,7 +219,7 @@ github "BranchMetrics/ios-branch-deep-linking"
           # 1. Patch Cartfile. Return if no change (Branch already present).
           return false unless PatchHelper.patch_cartfile cartfile_path
 
-          # 2. carthage update
+          # 2. carthage bootstrap (or other command)
           cmd = "carthage #{options.carthage_command}"
           cmd << " ios-branch-deep-linking" if options.carthage_command =~ /^(update|build)/
           sh cmd, chdir: File.dirname(config.cartfile_path)


### PR DESCRIPTION
When using the carthage `build` or `update` command, the command is limited to the `ios-branch-deep-linking` dependency. In the current release this is also added to `bootstrap` and other commands. `carthage bootstrap ios-branch-deep-linking` will fail if the dependency is not already in the `Cartfile.resolved`. Now this command will succeed because the extra argument is not supplied.

If the report command is using a Cartfile (by inference or argument), it will verify that `Carthage/Build/iOS` exists and offer to `carthage checkout && carthage build --platform ios` if not, in order to build.

There is now a `--[no]-confirm` option to the report command that controls this behavior and similar CocoaPods behavior. Using `--no-confirm`, the command will run `pod install` or `carthage bootstrap` without a prompt. This is now used in the `report:full` Rake task in this repo.