### PR TITLE
Fixes for CocoaPods and URI scheme prompt

### DIFF
--- a/lib/branch_io_cli/command/setup_command.rb
+++ b/lib/branch_io_cli/command/setup_command.rb
@@ -31,11 +31,11 @@ module BranchIOCLI
           sh "pod install", chdir: File.dirname(config.podfile_path)
         end
 
-        # Add SDK via CocoaPods, Carthage or direct download (no-op if disabled).
-        add_sdk
-
         # Set up Universal Links and Branch key(s)
         update_project_settings
+
+        # Add SDK via CocoaPods, Carthage or direct download (no-op if disabled).
+        add_sdk
 
         # Patch source code if so instructed.
         patch_helper.patch_source config.xcodeproj if config.patch_source

--- a/lib/branch_io_cli/configuration/report_configuration.rb
+++ b/lib/branch_io_cli/configuration/report_configuration.rb
@@ -12,6 +12,11 @@ module BranchIOCLI
 
       attr_reader :report_path
 
+      def initialize(options)
+        @confirm = options.confirm
+        super
+      end
+
       def validate_options
         @clean = options.clean
         @header_only = options.header_only

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -31,6 +31,7 @@ module BranchIOCLI
       attr_reader :all_domains
 
       def initialize(options)
+        @confirm = options.confirm
         super
         # Configuration has been validated and logged to the screen.
         confirm_with_user if options.confirm

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -179,7 +179,7 @@ module BranchIOCLI
         uri_scheme = options.uri_scheme
 
         if confirm
-          uri_scheme ||= ask "Please enter any URI scheme you entered in the Branch Dashboard (optional). "
+          uri_scheme ||= ask "Please enter any URI scheme you entered in the Branch Dashboard [enter for none]: "
         end
 
         @uri_scheme = self.class.uri_scheme_without_suffix uri_scheme


### PR DESCRIPTION
- Perform all project configuration updates before SDK addition. This can be an issue when adding CocoaPods to a project using the CLI.
- Make sure configuration state is stored on initialization of the configuration class to ensure a prompt for the URI scheme.
- Improved URI scheme prompt to be consistent with key prompts.