### PR TITLE
Disable URI scheme prompt without --no-confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See https://github.com/BranchMetrics/branch_io_cli#setup-command for more inform
 |-T, --test-key key_test_yyyy|Branch test key|BRANCH_TEST_KEY|
 |-D, --domains example.com,www.example.com|Comma-separated list of custom domain(s) or non-Branch domain(s)|BRANCH_DOMAINS|
 |--app-link-subdomain myapp|Branch app.link subdomain, e.g. myapp for myapp.app.link|BRANCH_APP_LINK_SUBDOMAIN|
-|-U, --uri-scheme myurischeme[://]|Custom URI scheme used in the Branch Dashboard for this app|BRANCH_URI_SCHEME|
+|-U, --[no-]uri-scheme [myurischeme[://]]|Custom URI scheme used in the Branch Dashboard for this app|BRANCH_URI_SCHEME|
 |-s, --setting [BRANCH_KEY_SETTING]|Use a custom build setting for the Branch key (default: Use Info.plist)|BRANCH_SETTING|
 |--[no-]test-configurations [config1,config2]|List of configurations that use the test key with a user-defined setting (default: Debug configurations)|BRANCH_TEST_CONFIGURATIONS|
 |--xcodeproj MyProject.xcodeproj|Path to an Xcode project to update|BRANCH_XCODEPROJ|

--- a/lib/branch_io_cli/configuration/setup_configuration.rb
+++ b/lib/branch_io_cli/configuration/setup_configuration.rb
@@ -178,6 +178,12 @@ module BranchIOCLI
         # No validation at the moment. Just strips off any trailing ://
         uri_scheme = options.uri_scheme
 
+        # --no-uri-scheme/uri_scheme: false
+        if options.uri_scheme == false
+          @uri_scheme = nil
+          return
+        end
+
         if confirm
           uri_scheme ||= ask "Please enter any URI scheme you entered in the Branch Dashboard [enter for none]: "
         end

--- a/lib/branch_io_cli/configuration/setup_options.rb
+++ b/lib/branch_io_cli/configuration/setup_options.rb
@@ -41,6 +41,7 @@ module BranchIOCLI
               type: String,
               aliases: "-U",
               label: "URI scheme",
+              negatable: true,
               convert_proc: ->(value) { Configuration.uri_scheme_without_suffix(value) }
             ),
             Option.new(


### PR DESCRIPTION
Made the URI scheme option negatable, to support `--no-uri-scheme` and `uri_scheme: false`. This disables the URI scheme prompt without disabling all prompts.