### PR TITLE
Ruby env in report command

### DIFF
--- a/branch_io_cli.gemspec
+++ b/branch_io_cli.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pattern_patch', '>= 0.5.4', '~> 0.5'
   spec.add_dependency 'plist', '~> 3.3'
   spec.add_dependency 'rubyzip', '~> 1.1'
+  spec.add_dependency 'tty-platform', '~> 0.1'
   spec.add_dependency 'xcodeproj', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.15'

--- a/lib/branch_io_cli/command/env_command.rb
+++ b/lib/branch_io_cli/command/env_command.rb
@@ -5,14 +5,7 @@ module BranchIOCLI
         if config.show_all?
           say "\n" unless config.quiet
           say "<%= color('CLI version:', BOLD) %> #{VERSION}"
-          say "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}"
-          say "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}"
-          say "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}"
-          say "<%= color('Installed from Homebrew:', BOLD) %> #{env.from_homebrew? ? 'yes' : 'no'}"
-          say "<%= color('GEM_HOME:', BOLD) %> #{obfuscate_user(Gem.dir)}"
-          say "<%= color('Lib path:', BOLD) %> #{display_path(env.lib_path)}"
-          say "<%= color('LOAD_PATH:', BOLD) %> #{$LOAD_PATH.map { |p| display_path(p) }}"
-          say "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}"
+          say env.ruby_header(include_load_path: true)
         else
           script_path = env.completion_script
           if script_path.nil?
@@ -23,16 +16,6 @@ module BranchIOCLI
         end
 
         0
-      end
-
-      def obfuscate_user(path)
-        path.gsub(ENV['HOME'], '~').gsub(ENV['USER'], '$USER')
-      end
-
-      def display_path(path)
-        path = path.gsub(Gem.dir, '$GEM_HOME')
-        path = obfuscate_user(path)
-        path
       end
     end
   end

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -18,6 +18,8 @@ module BranchIOCLI
         end
 
         if config.header_only
+          say "\n"
+          say report_helper.ruby_header
           say report_helper.report_header
           return 0
         end
@@ -35,6 +37,13 @@ module BranchIOCLI
       def write_report(report)
         report.write "Branch.io Xcode build report v #{VERSION} #{Time.now}\n\n"
         report.write "#{config.report_configuration}\n"
+
+        if report == STDOUT
+          say report_helper.ruby_header
+        else
+          report.write report_helper.ruby_header(terminal: false)
+        end
+
         report.write "#{report_helper.report_header}\n"
 
         tool_helper.pod_install_if_required report

--- a/lib/branch_io_cli/command/report_command.rb
+++ b/lib/branch_io_cli/command/report_command.rb
@@ -19,7 +19,7 @@ module BranchIOCLI
 
         if config.header_only
           say "\n"
-          say report_helper.ruby_header
+          say env.ruby_header
           say report_helper.report_header
           return 0
         end
@@ -39,9 +39,9 @@ module BranchIOCLI
         report.write "#{config.report_configuration}\n"
 
         if report == STDOUT
-          say report_helper.ruby_header
+          say env.ruby_header
         else
-          report.write report_helper.ruby_header(terminal: false)
+          report.write env.ruby_header(terminal: false, include_load_path: true)
         end
 
         report.write "#{report_helper.report_header}\n"

--- a/lib/branch_io_cli/configuration/env_configuration.rb
+++ b/lib/branch_io_cli/configuration/env_configuration.rb
@@ -23,8 +23,8 @@ module BranchIOCLI
         return if quiet
 
         say <<EOF
-<%= color('Completion script:', BOLD) %> #{completion_script}
-<%= color('Shell:', BOLD) %> #{shell}
+<%= color('Show completion script:', BOLD) %> #{completion_script}
+<%= color('Shell for completion script:', BOLD) %> #{shell}
 EOF
       end
 

--- a/lib/branch_io_cli/configuration/environment.rb
+++ b/lib/branch_io_cli/configuration/environment.rb
@@ -65,12 +65,11 @@ module BranchIOCLI
           File.join lib_path, "assets"
         end
 
-        # Returns the last path component as a symbol, e.g.
-        # :bash, :zsh. Uses the SHELL env. var. unless overriden
+        # Returns the last path component. Uses the SHELL env. var. unless overriden
         # at the command line (br env -cs zsh).
         def shell
-          return ENV["SHELL"] unless config.respond_to?(:shell)
-          config.shell.split("/").last.to_sym
+          return ENV["SHELL"].split("/").last unless config.class.available_options.map(&:name).include?(:shell)
+          config.shell.split("/").last
         end
 
         def completion_script
@@ -79,15 +78,16 @@ module BranchIOCLI
         end
 
         def ruby_header(terminal: true, include_load_path: false)
-          header = header_item("Operating system", operating_system)
-          header += header_item("Ruby version", RUBY_VERSION)
-          header += header_item("RubyGems version", Gem::VERSION)
-          header += header_item("Bundler", defined?(Bundler) ? Bundler::VERSION : "no")
-          header += header_item("Installed from Homebrew", from_homebrew? ? "yes" : "no")
-          header += header_item("GEM_HOME", obfuscate_user(Gem.dir))
-          header += header_item("Lib path", display_path(lib_path))
-          header += header_item("LOAD_PATH", $LOAD_PATH.map { |p| display_path(p) }) if include_load_path
-          header += header_item("Shell", ENV["SHELL"])
+          header = header_item("Operating system", operating_system, terminal: terminal)
+          header += header_item("Ruby version", RUBY_VERSION, terminal: terminal)
+          header += header_item("Ruby path", display_path(ruby_path), terminal: terminal)
+          header += header_item("RubyGems version", Gem::VERSION, terminal: terminal)
+          header += header_item("Bundler", defined?(Bundler) ? Bundler::VERSION : "no", terminal: terminal)
+          header += header_item("Installed from Homebrew", from_homebrew? ? "yes" : "no", terminal: terminal)
+          header += header_item("GEM_HOME", obfuscate_user(Gem.dir), terminal: terminal)
+          header += header_item("Lib path", display_path(lib_path), terminal: terminal)
+          header += header_item("LOAD_PATH", $LOAD_PATH.map { |p| display_path(p) }, terminal: terminal) if include_load_path
+          header += header_item("Shell", ENV["SHELL"], terminal: terminal)
           header += "\n"
           header
         end

--- a/lib/branch_io_cli/configuration/environment.rb
+++ b/lib/branch_io_cli/configuration/environment.rb
@@ -20,14 +20,48 @@ module BranchIOCLI
 
         # Returns the last path component as a symbol, e.g.
         # :bash, :zsh. Uses the SHELL env. var. unless overriden
-        # at the command line (br env -c -s zsh).
+        # at the command line (br env -cs zsh).
         def shell
+          return ENV["SHELL"] unless config.respond_to?(:shell)
           config.shell.split("/").last.to_sym
         end
 
         def completion_script
           path = File.join assets_path, "completions", "completion.#{shell}"
           path if File.readable?(path)
+        end
+
+        def ruby_header(terminal: true, include_load_path: false)
+          if terminal
+            header = "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
+            header += "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}\n"
+            header += "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
+            header += "<%= color('Installed from Homebrew:', BOLD) %> #{from_homebrew? ? 'yes' : 'no'}\n"
+            header += "<%= color('GEM_HOME:', BOLD) %> #{obfuscate_user(Gem.dir)}\n"
+            header += "<%= color('Lib path:', BOLD) %> #{display_path(lib_path)}\n"
+            header += "<%= color('LOAD_PATH:', BOLD) %> #{$LOAD_PATH.map { |p| display_path(p) }}\n" if include_load_path
+            header += "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}\n\n"
+          else
+            header = "Ruby version: #{RUBY_VERSION}\n"
+            header += "RubyGems version: #{Gem::VERSION}\n"
+            header += "Bundler: #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
+            header += "Installed from Homebrew: #{from_homebrew? ? 'yes' : 'no'}\n"
+            header += "GEM_HOME: #{obfuscate_user(Gem.dir)}\n"
+            header += "Lib path: #{display_path(lib_path)}\n"
+            header += "LOAD_PATH: #{$LOAD_PATH.map { |p| display_path(p) }}\n" if include_load_path
+            header += "Shell: #{ENV['SHELL']}\n\n"
+          end
+          header
+        end
+
+        def obfuscate_user(path)
+          path.gsub(ENV['HOME'], '~').gsub(ENV['USER'], '$USER')
+        end
+
+        def display_path(path)
+          path = path.gsub(Gem.dir, '$GEM_HOME')
+          path = obfuscate_user(path)
+          path
         end
       end
     end

--- a/lib/branch_io_cli/configuration/environment.rb
+++ b/lib/branch_io_cli/configuration/environment.rb
@@ -79,30 +79,25 @@ module BranchIOCLI
         end
 
         def ruby_header(terminal: true, include_load_path: false)
-          if terminal
-            header = "<%= color('Operating system:', BOLD) %> #{operating_system}\n"
-            header += "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
-            header += "<%= color('Ruby path:', BOLD) %> #{obfuscate_user(ruby_path)}\n"
-            header += "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}\n"
-            header += "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
-            header += "<%= color('Installed from Homebrew:', BOLD) %> #{from_homebrew? ? 'yes' : 'no'}\n"
-            header += "<%= color('GEM_HOME:', BOLD) %> #{obfuscate_user(Gem.dir)}\n"
-            header += "<%= color('Lib path:', BOLD) %> #{display_path(lib_path)}\n"
-            header += "<%= color('LOAD_PATH:', BOLD) %> #{$LOAD_PATH.map { |p| display_path(p) }}\n" if include_load_path
-            header += "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}\n\n"
-          else
-            header = "Operating system: #{operating_system}\n"
-            header += "Ruby version: #{RUBY_VERSION}\n"
-            header += "Ruby path: #{obfuscate_user(ruby_path)}\n"
-            header += "RubyGems version: #{Gem::VERSION}\n"
-            header += "Bundler: #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
-            header += "Installed from Homebrew: #{from_homebrew? ? 'yes' : 'no'}\n"
-            header += "GEM_HOME: #{obfuscate_user(Gem.dir)}\n"
-            header += "Lib path: #{display_path(lib_path)}\n"
-            header += "LOAD_PATH: #{$LOAD_PATH.map { |p| display_path(p) }}\n" if include_load_path
-            header += "Shell: #{ENV['SHELL']}\n\n"
-          end
+          header = header_item("Operating system", operating_system)
+          header += header_item("Ruby version", RUBY_VERSION)
+          header += header_item("RubyGems version", Gem::VERSION)
+          header += header_item("Bundler", defined?(Bundler) ? Bundler::VERSION : "no")
+          header += header_item("Installed from Homebrew", from_homebrew? ? "yes" : "no")
+          header += header_item("GEM_HOME", obfuscate_user(Gem.dir))
+          header += header_item("Lib path", display_path(lib_path))
+          header += header_item("LOAD_PATH", $LOAD_PATH.map { |p| display_path(p) }) if include_load_path
+          header += header_item("Shell", ENV["SHELL"])
+          header += "\n"
           header
+        end
+
+        def header_item(label, value, terminal: true)
+          if terminal
+            "<%= color('#{label}:', BOLD) %> #{value}\n"
+          else
+            "label: #{value}\n"
+          end
         end
 
         def obfuscate_user(path)

--- a/lib/branch_io_cli/configuration/environment.rb
+++ b/lib/branch_io_cli/configuration/environment.rb
@@ -1,9 +1,56 @@
+require "active_support/core_ext/string"
+require "rbconfig"
+require "branch_io_cli/core_ext/tty_platform"
+
 module BranchIOCLI
   module Configuration
     class Environment
+      PLATFORM = TTY::Platform.new
+
       class << self
         def config
           Configuration.current
+        end
+
+        def os_version
+          PLATFORM.version
+        end
+
+        def os_name
+          PLATFORM.os.to_s.capitalize
+        end
+
+        def os_cpu
+          PLATFORM.cpu
+        end
+
+        def os_arch
+          PLATFORM.architecture
+        end
+
+        def operating_system
+          if PLATFORM.br_high_sierra?
+            os = "macOS High Sierra"
+          elsif PLATFORM.br_sierra?
+            os = "macOS Sierra"
+          else
+            os = os_name if os_name
+            os += " #{os_version}" if os_version
+          end
+
+          if os_cpu
+            os += " (#{os_cpu} #{os_arch})"
+          else
+            os += "(#{os_arch})"
+          end
+
+          os
+        end
+
+        def ruby_path
+          File.join(RbConfig::CONFIG["bindir"],
+                    RbConfig::CONFIG["RUBY_INSTALL_NAME"] +
+                    RbConfig::CONFIG["EXEEXT"])
         end
 
         def from_homebrew?
@@ -33,7 +80,9 @@ module BranchIOCLI
 
         def ruby_header(terminal: true, include_load_path: false)
           if terminal
-            header = "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
+            header = "<%= color('Operating system:', BOLD) %> #{operating_system}\n"
+            header += "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
+            header += "<%= color('Ruby path:', BOLD) %> #{obfuscate_user(ruby_path)}\n"
             header += "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}\n"
             header += "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
             header += "<%= color('Installed from Homebrew:', BOLD) %> #{from_homebrew? ? 'yes' : 'no'}\n"
@@ -42,7 +91,9 @@ module BranchIOCLI
             header += "<%= color('LOAD_PATH:', BOLD) %> #{$LOAD_PATH.map { |p| display_path(p) }}\n" if include_load_path
             header += "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}\n\n"
           else
-            header = "Ruby version: #{RUBY_VERSION}\n"
+            header = "Operating system: #{operating_system}\n"
+            header += "Ruby version: #{RUBY_VERSION}\n"
+            header += "Ruby path: #{obfuscate_user(ruby_path)}\n"
             header += "RubyGems version: #{Gem::VERSION}\n"
             header += "Bundler: #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
             header += "Installed from Homebrew: #{from_homebrew? ? 'yes' : 'no'}\n"

--- a/lib/branch_io_cli/core_ext.rb
+++ b/lib/branch_io_cli/core_ext.rb
@@ -1,3 +1,4 @@
 require "branch_io_cli/core_ext/io.rb"
 require "branch_io_cli/core_ext/regexp.rb"
+require "branch_io_cli/core_ext/tty_platform.rb"
 require "branch_io_cli/core_ext/xcodeproj.rb"

--- a/lib/branch_io_cli/core_ext/tty_platform.rb
+++ b/lib/branch_io_cli/core_ext/tty_platform.rb
@@ -1,0 +1,13 @@
+require "tty/platform"
+
+module TTY
+  class Platform
+    def br_sierra?
+      mac? && version.to_s == "16"
+    end
+
+    def br_high_sierra?
+      mac? && version.to_s == "17"
+    end
+  end
+end

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -26,16 +26,6 @@ module BranchIOCLI
           Configuration::Environment
         end
 
-        def obfuscate_user(path)
-          path.gsub(ENV['HOME'], '~').gsub(ENV['USER'], '$USER')
-        end
-
-        def display_path(path)
-          path = path.gsub(Gem.dir, '$GEM_HOME')
-          path = obfuscate_user(path)
-          path
-        end
-
         def helper
           BranchHelper
         end
@@ -57,28 +47,6 @@ module BranchIOCLI
           report += " Configurations:\n"
           report += "  #{config.configurations_from_scheme.join("\n  ")}\n"
           report
-        end
-
-        def ruby_header(terminal: true)
-          if terminal
-            header = "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
-            header += "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}\n"
-            header += "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
-            header += "<%= color('Installed from Homebrew:', BOLD) %> #{env.from_homebrew? ? 'yes' : 'no'}\n"
-            header += "<%= color('GEM_HOME:', BOLD) %> #{obfuscate_user(Gem.dir)}\n"
-            header += "<%= color('Lib path:', BOLD) %> #{display_path(env.lib_path)}\n"
-            header += "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}\n\n"
-          else
-            header = "Ruby version: #{RUBY_VERSION}\n"
-            header += "RubyGems version: #{Gem::VERSION}\n"
-            header += "Bundler: #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
-            header += "Installed from Homebrew: #{env.from_homebrew? ? 'yes' : 'no'}\n"
-            header += "GEM_HOME: #{obfuscate_user(Gem.dir)}\n"
-            header += "Lib path: #{display_path(env.lib_path)}\n"
-            header += "LOAD_PATH: #{$LOAD_PATH.map { |p| display_path(p) }}\n"
-            header += "Shell: #{ENV['SHELL']}\n\n"
-          end
-          header
         end
 
         # rubocop: disable Metrics/PerceivedComplexity

--- a/lib/branch_io_cli/helper/report_helper.rb
+++ b/lib/branch_io_cli/helper/report_helper.rb
@@ -22,6 +22,20 @@ module BranchIOCLI
           Configuration::Configuration.current
         end
 
+        def env
+          Configuration::Environment
+        end
+
+        def obfuscate_user(path)
+          path.gsub(ENV['HOME'], '~').gsub(ENV['USER'], '$USER')
+        end
+
+        def display_path(path)
+          path = path.gsub(Gem.dir, '$GEM_HOME')
+          path = obfuscate_user(path)
+          path
+        end
+
         def helper
           BranchHelper
         end
@@ -43,6 +57,28 @@ module BranchIOCLI
           report += " Configurations:\n"
           report += "  #{config.configurations_from_scheme.join("\n  ")}\n"
           report
+        end
+
+        def ruby_header(terminal: true)
+          if terminal
+            header = "<%= color('Ruby version:', BOLD) %> #{RUBY_VERSION}\n"
+            header += "<%= color('RubyGems version:', BOLD) %> #{Gem::VERSION}\n"
+            header += "<%= color('Bundler:', BOLD) %> #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
+            header += "<%= color('Installed from Homebrew:', BOLD) %> #{env.from_homebrew? ? 'yes' : 'no'}\n"
+            header += "<%= color('GEM_HOME:', BOLD) %> #{obfuscate_user(Gem.dir)}\n"
+            header += "<%= color('Lib path:', BOLD) %> #{display_path(env.lib_path)}\n"
+            header += "<%= color('Shell:', BOLD) %> #{ENV['SHELL']}\n\n"
+          else
+            header = "Ruby version: #{RUBY_VERSION}\n"
+            header += "RubyGems version: #{Gem::VERSION}\n"
+            header += "Bundler: #{defined?(Bundler) ? Bundler::VERSION : 'no'}\n"
+            header += "Installed from Homebrew: #{env.from_homebrew? ? 'yes' : 'no'}\n"
+            header += "GEM_HOME: #{obfuscate_user(Gem.dir)}\n"
+            header += "Lib path: #{display_path(env.lib_path)}\n"
+            header += "LOAD_PATH: #{$LOAD_PATH.map { |p| display_path(p) }}\n"
+            header += "Shell: #{ENV['SHELL']}\n\n"
+          end
+          header
         end
 
         # rubocop: disable Metrics/PerceivedComplexity


### PR DESCRIPTION
Added Ruby/OS environment info to report command output.

Some refactoring. Use `tty-platform` to detect the operating system. This anticipates cross-platform support for Android in the future.